### PR TITLE
Support concurrent parsing

### DIFF
--- a/context.js
+++ b/context.js
@@ -16,6 +16,9 @@ class Context {
     // args to parse per type
     this.args = []
     this.slurped = []
+    // values by type, keyed by type.id
+    this.values = new Map()
+    this.sources = new Map()
     // results of parsing and validation
     this.code = 0
     this.output = ''
@@ -203,6 +206,35 @@ class Context {
     if (typeof this.versionRequested.version === 'function') this.output = this.versionRequested.version()
     else this.output = this.versionRequested.version
     return this
+  }
+
+  // weird method names make for easier code searching
+  assignValue (id, value) {
+    this.values.set(id, value)
+  }
+
+  lookupValue (id) {
+    return this.values.get(id)
+  }
+
+  employSource (id, source, position, raw) {
+    let obj = this.lookupSource(id)
+    if (!obj) {
+      obj = { source: undefined, position: [], raw: [] }
+      this.sources.set(id, obj)
+    }
+    if (typeof source === 'string') obj.source = source
+    if (typeof position === 'number') obj.position.push(position)
+    if (typeof raw === 'string') obj.raw.push(raw)
+  }
+
+  lookupSource (id) {
+    return this.sources.get(id)
+  }
+
+  lookupSourceValue (id) {
+    const obj = this.lookupSource(id)
+    return obj && obj.source
   }
 
   populateArgv (typeResults) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -146,7 +146,7 @@ class Utils {
       firstEqual = value.indexOf('=')
       if (firstEqual !== -1) {
         props.defaultValue = value.slice(firstEqual + 1)
-        if (props.variadic) props.defaultValue = [props.defaultValue] // TODO TypeArray with defaultValue has problems!
+        if (props.variadic) props.defaultValue = [props.defaultValue]
         value = value.slice(0, firstEqual)
       }
 

--- a/test/test-parse.js
+++ b/test/test-parse.js
@@ -154,7 +154,7 @@ tap.test('api parse > multiple sequential passes', t => {
   })
 })
 
-tap.test('api parse > multiple concurrent passes', {skip: true}, t => {
+tap.test('api parse > multiple concurrent passes', t => {
   const api = Api.get()
     .boolean('--bool | -b')
     .string('--str  | -s <value>')

--- a/types/boolean.js
+++ b/types/boolean.js
@@ -15,12 +15,12 @@ class TypeBoolean extends Type {
     return 'boolean'
   }
 
-  isApplicable (currentValue, previousValue, slurpedArg) {
+  isApplicable (context, currentValue, previousValue, slurpedArg) {
     return typeof currentValue === 'boolean' || currentValue === 'true' || currentValue === 'false'
   }
 
-  setValue (value) {
-    this._value = typeof value === 'boolean' ? value : value === 'true'
+  setValue (context, value) {
+    context.assignValue(this.id, typeof value === 'boolean' ? value : value === 'true')
   }
 }
 

--- a/types/command.js
+++ b/types/command.js
@@ -8,6 +8,11 @@ class TypeCommand extends Type {
     return new TypeCommand(opts)
   }
 
+  constructor (opts) {
+    // default value is for benefit of context.details.types
+    super(Object.assign({ defaultValue: false }, opts))
+  }
+
   configure (opts, override) {
     opts = opts || {}
     if (typeof override === 'undefined') override = true
@@ -87,11 +92,11 @@ class TypeCommand extends Type {
       let matchedArg = context.slurped.find(arg => arg.parsed.length === 1 && !arg.parsed[0].key && !arg.parsed[0].claimed)
       if (matchedArg) {
         matchedArg.parsed[0].claimed = true
-        this.applySource(Type.SOURCE_POSITIONAL, matchedArg.index, matchedArg.raw)
+        this.applySource(context, Type.SOURCE_POSITIONAL, matchedArg.index, matchedArg.raw)
       }
     }
-    this.setValue(true) // set this value to true for context.details
-    context.populateArgv([this.toResult()]) // apply value to context.details
+    this.setValue(context, true) // set this value to true for context.details
+    context.populateArgv([this.toResult(context)]) // apply value to context.details
 
     // add positionals from preconfigured opts
     if (typeof this._positionalDsl === 'string' && this._positionalDsl.length) {

--- a/types/enum.js
+++ b/types/enum.js
@@ -47,8 +47,8 @@ class TypeEnum extends TypeString {
     })
   }
 
-  buildInvalidMessage (msgAndArgs) {
-    super.buildInvalidMessage(msgAndArgs)
+  buildInvalidMessage (context, msgAndArgs) {
+    super.buildInvalidMessage(context, msgAndArgs)
     if (this.choices.length) {
       msgAndArgs.msg += ' Choices are: %s'
       msgAndArgs.args.push(this.choices.join(', '))

--- a/types/help.js
+++ b/types/help.js
@@ -38,12 +38,12 @@ class TypeHelp extends TypeImplicitCommand {
   }
 
   validateParsed (context) {
-    if (this.value) this.requestHelp(context) // must call this before postParse in case of commands
+    if (this.getValue(context)) this.requestHelp(context) // must call this before postParse in case of commands
     return this.resolve()
   }
 
-  implicitCommandFound (source, position, raw, context) {
-    super.implicitCommandFound(source, position, raw, context)
+  implicitCommandFound (context, source, position, raw) {
+    super.implicitCommandFound(context, source, position, raw)
     this.requestHelp(context) // must call this before postParse in case of commands
   }
 

--- a/types/implicit.js
+++ b/types/implicit.js
@@ -30,9 +30,9 @@ class TypeImplicitCommand extends TypeBoolean {
     super.buildHelpHints(hints)
   }
 
-  implicitCommandFound (source, position, raw, context) {
-    this.setValue(true)
-    this.applySource(source, position, raw)
+  implicitCommandFound (context, source, position, raw) {
+    this.setValue(context, true)
+    this.applySource(context, source, position, raw)
   }
 }
 

--- a/types/number.js
+++ b/types/number.js
@@ -15,13 +15,14 @@ class TypeNumber extends Type {
     return 'number'
   }
 
-  get value () {
-    if (typeof this._value === 'undefined' || this._value === null) return this._value
-    return TypeNumber.isNumber(this._value) ? Number(this._value) : NaN
+  getValue (context) {
+    const v = context.lookupValue(this.id)
+    if (typeof v === 'undefined' || v === null) return v
+    return TypeNumber.isNumber(v) ? Number(v) : NaN
   }
 
-  setValue (value) {
-    this._value = typeof value === 'boolean' ? NaN : value
+  setValue (context, value) {
+    context.assignValue(this.id, typeof value === 'boolean' ? NaN : value)
   }
 
   // this is only checked if isStrict
@@ -29,8 +30,8 @@ class TypeNumber extends Type {
     return TypeNumber.isNumber(value) && !isNaN(value)
   }
 
-  buildInvalidMessage (msgAndArgs) {
-    super.buildInvalidMessage(msgAndArgs)
+  buildInvalidMessage (context, msgAndArgs) {
+    super.buildInvalidMessage(context, msgAndArgs)
     msgAndArgs.msg += ' Please specify a number.'
   }
 }

--- a/types/path.js
+++ b/types/path.js
@@ -108,8 +108,8 @@ class TypePath extends TypeString {
     if (msg) context.cliMessage(msg, actualType, value)
   }
 
-  get value () {
-    let value = super.value
+  getValue (context) {
+    let value = super.getValue(context)
     if (value && this._normalize) value = this.pathLib.normalize(value)
     if (value && this._asObject) value = this.pathLib.parse(value)
     return value

--- a/types/positional.js
+++ b/types/positional.js
@@ -63,26 +63,21 @@ class TypePositional extends TypeWrapper {
   }
 
   // called by unknownType
-  setValue (value) {
-    this.elementType.setValue(value)
+  setValue (context, value) {
+    this.elementType.setValue(context, value)
   }
 
   // called by unknownType
-  applySource (source, position, raw) {
-    this.elementType.applySource(source, position, raw)
+  applySource (context, source, position, raw) {
+    this.elementType.applySource(context, source, position, raw)
   }
 
   get source () {
     return this.elementType.source
   }
 
-  reset () {
-    super.reset()
-    this.elementType.reset()
-  }
-
-  toResult (shouldCoerce) {
-    return this.elementType.toResult(shouldCoerce)
+  toResult (context, shouldCoerce) {
+    return this.elementType.toResult(context, shouldCoerce)
   }
 }
 

--- a/types/string.js
+++ b/types/string.js
@@ -7,22 +7,18 @@ class TypeString extends Type {
     return new TypeString(opts)
   }
 
-  // constructor (opts) {
-  //   super(opts)
-  // }
-
   get datatype () {
     return 'string'
   }
 
-  get value () {
-    if (typeof this._value === 'undefined' || this._value === null) return this._value
-    return String(this._value)
+  getValue (context) {
+    const v = context.lookupValue(this.id)
+    if (typeof v === 'undefined' || v === null) return v
+    return String(v)
   }
 
-  setValue (value) {
-    // console.log('string.js > setValue:', value)
-    this._value = typeof value === 'boolean' ? '' : value
+  setValue (context, value) {
+    context.assignValue(this.id, typeof value === 'boolean' ? '' : value)
   }
 }
 

--- a/types/version.js
+++ b/types/version.js
@@ -38,12 +38,12 @@ class TypeVersion extends TypeImplicitCommand {
   }
 
   validateParsed (context) {
-    if (this.value) this.requestVersion(context) // must call this before postParse in case of commands
+    if (this.getValue(context)) this.requestVersion(context) // must call this before postParse in case of commands
     return this.resolve()
   }
 
-  implicitCommandFound (source, position, raw, context) {
-    super.implicitCommandFound(source, position, raw, context)
+  implicitCommandFound (context, source, position, raw) {
+    super.implicitCommandFound(context, source, position, raw)
     this.requestVersion(context) // must call this before postParse in case of commands
   }
 


### PR DESCRIPTION
Doing this the ol' PR way since it was a significant refactor.

Pretty early on I thought it would be best (in terms of efficiency) to maintain parsed values of all types within the context instance instead of across all type instances, but holding the state within the type had a lot of coding conveniences, so I thought I could get away with it.

Then, once I started writing tests, I realized that although I could configure an Api instance once and reuse it for multiple calls to parse (as was an original design goal), I couldn't reuse it _concurrently_ (run `api.parse(args)` in different async tasks/promises) due to instance state in types (the same type instances, once configured, are used across different parse executions).

This was obviously a big problem (especially in use-cases like chatbots or server apps where one sywac instance/config should be used to parse/service multiple concurrent messages/requests) and was in direct contradiction of a primary design goal.

Therefore, it was time to bite the bullet and move all state specific to a parse execution (i.e. parsed values and source/position/raw arg details) into Context, since each parse execution has its own Context instance.

This PR represents that refactoring. And, although we now have to pass around a context to almost every type method (I didn't try using continuation local storage or a Domain), it turns out this comes with additional benefits of better efficiency/performance, clearer separation of concerns, and even fixes bugs with an array type default value. This makes me happy. 😎 