### PR TITLE
fix: allow dashes as unknown args

### DIFF
--- a/api.js
+++ b/api.js
@@ -18,7 +18,7 @@ class Api {
     this._factories = {
       // meta
       unknownType: this.getUnknownType,
-      context: this.getContext,
+      _context: this.getContext,
       helpBuffer: this.getHelpBuffer,
       // common types
       boolean: this.getBoolean,
@@ -613,7 +613,7 @@ class Api {
   }
 
   initContext (includeTypes) {
-    let context = this.get('context', { utils: this.utils })
+    let context = this.get('_context', { utils: this.utils })
     return includeTypes ? this.applyTypes(context) : context
   }
 

--- a/context.js
+++ b/context.js
@@ -97,6 +97,13 @@ class Context {
     let kvDelimIndex = arg.indexOf('=')
     let flags = kvDelimIndex > 1 ? arg.substring(numBeginningDashes, kvDelimIndex) : arg.slice(numBeginningDashes)
     let value = kvDelimIndex > 1 ? arg.substring(kvDelimIndex + 1) : undefined
+    // allow an arg of just dashes e.g. '-'
+    if (!flags && !value) {
+      return [{
+        key: '',
+        value: arg
+      }]
+    }
     // can only be one flag with more than 1 dash
     if (numBeginningDashes > 1) {
       return [{


### PR DESCRIPTION
Make it so `program -` results in `argv._` value of `['-']`.

Otherwise, arguments that are just dashes (besides the special `--`) are swallowed.

This also changes the factory name for the Context class from `'context'` to `'_context'` so that positional args or custom type factories can use the name `context`.

The new test also verifies the ability to plugin a customized Context class, as a secondary bonus.