### PR TITLE
feat: add Api.commandDirectory(dir, opts) method

### DIFF
--- a/api.js
+++ b/api.js
@@ -299,11 +299,20 @@ class Api {
       if (dir && typeof dir === 'string') searchDir = this.pathLib.resolve(searchDir, dir)
     }
     let filepath
+    let mod
     this.fsLib.readdirSync(searchDir).forEach(fileInDir => {
       filepath = this.pathLib.join(searchDir, fileInDir)
       if (opts.extensions.indexOf(this.pathLib.extname(fileInDir)) !== -1 && this._modulesSeen.indexOf(filepath) === -1) {
         this._modulesSeen.push(filepath)
-        this._internalCommand(require(filepath))
+        mod = require(filepath)
+        if (mod.flags || mod.aliases) {
+          this._internalCommand(mod)
+        } else if (typeof mod === 'function') {
+          this._internalCommand({
+            aliases: this.pathLib.basename(fileInDir, this.pathLib.extname(fileInDir)),
+            run: mod
+          })
+        }
       }
     })
     return this

--- a/api.js
+++ b/api.js
@@ -38,6 +38,7 @@ class Api {
     }
     this._showHelpByDefault = 'showHelpByDefault' in opts ? opts.showHelpByDefault : false
     this._magicCommandAdded = false
+    this._modulesSeen = opts.modulesSeen || []
     this.configure(opts)
     if (!Api.ROOT_NAME) Api.ROOT_NAME = this.name
   }
@@ -46,6 +47,8 @@ class Api {
     opts = opts || {}
     // lazily configured instance dependencies (expects a single instance)
     this._utils = opts.utils || this._utils
+    this._pathLib = opts.pathLib || this._pathLib
+    this._fsLib = opts.fsLib || this._fsLib
 
     // lazily configured factory dependencies (expects a function to call per instance)
     if ('factories' in opts) {
@@ -66,6 +69,7 @@ class Api {
       utils: this.utils,
       name: this.name + ' ' + commandName,
       parentName: this.name,
+      modulesSeen: this._modulesSeen.slice(),
       helpOpts: this._assignHelpOpts({}, this.helpOpts),
       showHelpByDefault: this._showHelpByDefault
     })
@@ -103,8 +107,18 @@ class Api {
     return this._helpOpts
   }
 
+  get pathLib () {
+    if (!this._pathLib) this._pathLib = require('path')
+    return this._pathLib
+  }
+
+  get fsLib () {
+    if (!this._fsLib) this._fsLib = require('fs')
+    return this._fsLib
+  }
+
   get name () {
-    if (typeof this._name !== 'string') this._name = require('path').basename(process.argv[1], '.js')
+    if (typeof this._name !== 'string') this._name = this.pathLib.basename(process.argv[1], '.js')
     return this._name
   }
 
@@ -268,6 +282,33 @@ class Api {
   }
 
   // complex types
+  commandDirectory (dir, opts) {
+    if (typeof dir === 'object') {
+      opts = dir
+      dir = ''
+    }
+    opts = Object.assign({}, opts)
+    if (!Array.isArray(opts.extensions)) opts.extensions = ['.js']
+    let searchDir
+    if (dir && typeof dir === 'string' && this.pathLib.isAbsolute(dir)) {
+      searchDir = dir
+    } else {
+      const callerFile = this.utils.getCallerFile()
+      if (this._modulesSeen.indexOf(callerFile) === -1) this._modulesSeen.push(callerFile)
+      searchDir = this.pathLib.dirname(callerFile)
+      if (dir && typeof dir === 'string') searchDir = this.pathLib.resolve(searchDir, dir)
+    }
+    let filepath
+    this.fsLib.readdirSync(searchDir).forEach(fileInDir => {
+      filepath = this.pathLib.join(searchDir, fileInDir)
+      if (opts.extensions.indexOf(this.pathLib.extname(fileInDir)) !== -1 && this._modulesSeen.indexOf(filepath) === -1) {
+        this._modulesSeen.push(filepath)
+        this._internalCommand(require(filepath))
+      }
+    })
+    return this
+  }
+
   command (dsl, opts) {
     this._internalCommand(dsl, opts)
     return this

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,6 +11,25 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
+// copyright license mentioned at https://github.com/stefanpenner/get-caller-file/blob/f6c31f706f3ec17b2d1b398f51d5bc21901477b7/package.json#L21
+// for the use of getCallerFile logic below
+/*
+ISC License
+
+Copyright (c) 2015, Stefan Penner
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+*/
 
 'use strict'
 
@@ -263,6 +282,14 @@ class Utils {
       if (one[i] !== two[i]) return false
     }
     return true
+  }
+
+  getCallerFile () {
+    const oldPrepareStackTrace = Error.prepareStackTrace
+    Error.prepareStackTrace = (_, stack) => stack
+    const stack = new Error().stack
+    Error.prepareStackTrace = oldPrepareStackTrace
+    return stack[2] ? stack[2].getFileName() : undefined
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "pretest": "standard",
-    "test": "FORCE_COLOR=1 tap --cov --jobs=4 test/test*.js test/lib/test*.js test/types/test*.js",
+    "test": "FORCE_COLOR=1 tap --cov --jobs=4 test/test*.js test/lib/test*.js test/types/test*.js test/fixture2/test*.js",
     "coverage": "nyc report --reporter=text-lcov | coveralls"
   },
   "engines": {

--- a/test/fixture2/cyclic/command.js
+++ b/test/fixture2/cyclic/command.js
@@ -1,0 +1,8 @@
+'use strict'
+
+module.exports = {
+  flags: 'command',
+  desc: 'Attempts to (re)apply its own dir',
+  setup: sywac => sywac.commandDirectory('../cyclic'),
+  run: argv => {}
+}

--- a/test/fixture2/level1/level2/level3/three.js
+++ b/test/fixture2/level1/level2/level3/three.js
@@ -1,0 +1,9 @@
+'use strict'
+
+module.exports = {
+  flags: 'three',
+  desc: 'Level three command',
+  run: argv => {
+    argv.threeRun = true
+  }
+}

--- a/test/fixture2/level1/level2/two.js
+++ b/test/fixture2/level1/level2/two.js
@@ -1,0 +1,6 @@
+'use strict'
+
+exports.flags = 'two <subcommand>'
+exports.ignore = '<subcommand>'
+exports.desc = 'Level two command'
+exports.setup = sywac => sywac.commandDirectory('level3')

--- a/test/fixture2/level1/one.js
+++ b/test/fixture2/level1/one.js
@@ -1,0 +1,8 @@
+'use strict'
+
+module.exports = {
+  flags: 'one <subcommand>',
+  ignore: '<subcommand>',
+  desc: 'Level one command',
+  setup: sywac => sywac.commandDirectory('level2')
+}

--- a/test/fixture2/level1/top.js
+++ b/test/fixture2/level1/top.js
@@ -1,0 +1,6 @@
+'use strict'
+
+module.exports = {
+  flags: 'top',
+  desc: 'Top level command'
+}

--- a/test/fixture2/level1/top.js
+++ b/test/fixture2/level1/top.js
@@ -1,6 +1,5 @@
 'use strict'
 
-module.exports = {
-  flags: 'top',
-  desc: 'Top level command'
+module.exports = argv => {
+  console.log('i am a valid, minimal command module that just defines an implicit run function')
 }

--- a/test/fixture2/module.mjs
+++ b/test/fixture2/module.mjs
@@ -1,0 +1,4 @@
+module.exports = {
+  flags: 'module',
+  desc: 'A module with mjs file extension'
+}

--- a/test/fixture2/not-a-command.js
+++ b/test/fixture2/not-a-command.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = 'hello world'

--- a/test/fixture2/random.js
+++ b/test/fixture2/random.js
@@ -1,0 +1,26 @@
+'use strict'
+
+module.exports = {
+  flags: 'random [max=1] [min=0]',
+  params: [
+    { type: 'number', desc: 'Desired ceiling' },
+    { type: 'number', desc: 'Desired floor' }
+  ],
+  desc: 'Get pseudo-random number',
+  setup: sywac => sywac.check(argv => {
+    if (isNaN(argv.min)) argv.min = 0
+    if (isNaN(argv.max)) argv.max = 1
+  }),
+  run: (argv, context) => {
+    let precision = 5
+    let r = Math.random()
+    if (argv.max !== 1 && argv.min) {
+      precision = 0
+      r = Math.floor(r * (argv.max - argv.min + 1)) + argv.min
+    } else if (argv.max !== 1) {
+      precision = 0
+      r = Math.floor(r * (argv.max + 1))
+    }
+    context.output = r.toFixed(precision)
+  }
+}

--- a/test/fixture2/test-special.js
+++ b/test/fixture2/test-special.js
@@ -1,0 +1,46 @@
+'use strict'
+
+const tap = require('tap')
+const Api = require('../../api')
+
+tap.test('commandDirectory > supports no arg (directory of caller)', t => {
+  return Api.get({ name: 'test' })
+    .commandDirectory()
+    .help()
+    .outputSettings({ maxWidth: 50 })
+    .parse('--help')
+    .then(result => {
+      t.equal(result.code, 0)
+      t.equal(result.errors.length, 0)
+      t.equal(result.output, [
+        'Usage: test <command> <args> [options]',
+        '',
+        'Commands:',
+        '  random [max=1] [min=0]  Get pseudo-random number',
+        '',
+        'Options:',
+        '  --help  Show help     [commands: help] [boolean]'
+      ].join('\n'))
+    })
+})
+
+tap.test('commandDirectory > supports opts only', t => {
+  return Api.get({ name: 'test' })
+    .commandDirectory({ extensions: ['.mjs'] })
+    .help()
+    .outputSettings({ maxWidth: 50 })
+    .parse('--help')
+    .then(result => {
+      t.equal(result.code, 0)
+      t.equal(result.errors.length, 0)
+      t.equal(result.output, [
+        'Usage: test <command> [options]',
+        '',
+        'Commands:',
+        '  module  A module with mjs file extension',
+        '',
+        'Options:',
+        '  --help  Show help     [commands: help] [boolean]'
+      ].join('\n'))
+    })
+})

--- a/test/lib/test-utils.js
+++ b/test/lib/test-utils.js
@@ -108,3 +108,9 @@ tap.test('utils > sameArrays', t => {
   t.equal(utils.sameArrays(['one', 'two'], ['one']), false)
   t.end()
 })
+
+tap.test('utils > getCallerFile', t => {
+  const wrapper = () => utils.getCallerFile() // have to add one more call to stack
+  t.equal(wrapper(), __filename)
+  t.end()
+})

--- a/test/test-command-directory.js
+++ b/test/test-command-directory.js
@@ -1,0 +1,128 @@
+'use strict'
+
+const tap = require('tap')
+const Api = require('../api')
+const path = require('path')
+
+tap.test('commandDirectory > supports multi-level', t => {
+  const api = Api.get({ name: 'test' })
+    .commandDirectory('fixture2/level1')
+    .showHelpByDefault()
+    .outputSettings({ maxWidth: 50 })
+
+  const promises = []
+
+  promises.push(api.parse('').then(result => {
+    t.equal(result.code, 0)
+    t.equal(result.errors.length, 0)
+    t.equal(result.output, [
+      'Usage: test <command> <args>',
+      '',
+      'Commands:',
+      '  one <subcommand>  Level one command',
+      '  top               Top level command'
+    ].join('\n'))
+  }))
+
+  promises.push(api.parse('one').then(result => {
+    t.equal(result.code, 0)
+    t.equal(result.errors.length, 0)
+    t.equal(result.output, [
+      'Usage: test one <subcommand>',
+      '',
+      'Commands:',
+      '  two <subcommand>  Level two command'
+    ].join('\n'))
+  }))
+
+  promises.push(api.parse('one two').then(result => {
+    t.equal(result.code, 0)
+    t.equal(result.errors.length, 0)
+    t.equal(result.output, [
+      'Usage: test one two <subcommand>',
+      '',
+      'Commands:',
+      '  three  Level three command'
+    ].join('\n'))
+  }))
+
+  promises.push(api.parse('one two three').then(result => {
+    t.equal(result.code, 0)
+    t.equal(result.errors.length, 0)
+    t.equal(result.output, '')
+    t.equal(result.argv.threeRun, true)
+  }))
+
+  return Promise.all(promises)
+})
+
+tap.test('commandDirectory > supports absolute', t => {
+  const absolutePath = path.join(__dirname, 'fixture2', 'level1')
+  return Api.get({ name: 'test' })
+    .commandDirectory(absolutePath)
+    .showHelpByDefault()
+    .outputSettings({ maxWidth: 50 })
+    .parse('')
+    .then(result => {
+      t.equal(result.code, 0)
+      t.equal(result.errors.length, 0)
+      t.equal(result.output, [
+        'Usage: test <command> <args>',
+        '',
+        'Commands:',
+        '  one <subcommand>  Level one command',
+        '  top               Top level command'
+      ].join('\n'))
+    })
+})
+
+tap.test('commandDirectory > detects and ignores cyclic reference', t => {
+  const api = Api.get({ name: 'test' })
+    .commandDirectory('fixture2/cyclic')
+    .help()
+    .outputSettings({ maxWidth: 50 })
+  return api.parse('--help').then(result => {
+    t.equal(result.code, 0)
+    t.equal(result.errors.length, 0)
+    t.equal(result.output, [
+      'Usage: test <command> [options]',
+      '',
+      'Commands:',
+      '  command  Attempts to (re)apply its own dir',
+      '',
+      'Options:',
+      '  --help  Show help     [commands: help] [boolean]'
+    ].join('\n'))
+    return api.parse('command --help')
+  }).then(result => {
+    t.equal(result.code, 0)
+    t.equal(result.errors.length, 0)
+    t.equal(result.output, [
+      'Usage: test command [options]',
+      '',
+      'Options:',
+      '  --help  Show help     [commands: help] [boolean]'
+    ].join('\n'))
+  })
+})
+
+tap.test('commandDirectory > throws on missing directory', t => {
+  t.throws(() => {
+    Api.get().commandDirectory('dne')
+  })
+  t.end()
+})
+
+tap.test('commandDirectory > throws on invalid require', t => {
+  t.throws(() => {
+    Api.get().commandDirectory('..', { extensions: ['.md'] })
+  })
+  t.end()
+})
+
+tap.test('commandDirectory > does not modify given opts', t => {
+  const opts = { key: 'value' }
+  Api.get().commandDirectory('./fixture2/level1', opts)
+  t.equal(Object.keys(opts).length, 1)
+  t.end()
+})

--- a/test/test-command-directory.js
+++ b/test/test-command-directory.js
@@ -124,5 +124,6 @@ tap.test('commandDirectory > does not modify given opts', t => {
   const opts = { key: 'value' }
   Api.get().commandDirectory('./fixture2/level1', opts)
   t.equal(Object.keys(opts).length, 1)
+  t.equal(opts.key, 'value')
   t.end()
 })

--- a/test/test-command-directory.js
+++ b/test/test-command-directory.js
@@ -20,7 +20,7 @@ tap.test('commandDirectory > supports multi-level', t => {
       '',
       'Commands:',
       '  one <subcommand>  Level one command',
-      '  top               Top level command'
+      '  top             '
     ].join('\n'))
   }))
 
@@ -71,7 +71,7 @@ tap.test('commandDirectory > supports absolute', t => {
         '',
         'Commands:',
         '  one <subcommand>  Level one command',
-        '  top               Top level command'
+        '  top             '
       ].join('\n'))
     })
 })


### PR DESCRIPTION
Introduces a new `Api` method that allows a directory to be specified as a string (either relative or absolute) so that all `require()`able modules in the directory are automatically added as commands.

This initial implementation:

- _DOES NOT SUPPORT_ recursion on subdirectories (a feature I don't think will be needed and do not plan to add)
- _DOES NOT SUPPORT_ custom module checks via `RegExp` inclusion/exclusion or custom function (I could be convinced to add this in the future)
- **DOES SUPPORT** specifying file extensions (via `opts.extensions`) that module files must have before `require()`ing them (default is just `['.js']`)

If no `dir` is specified, the method will use the directory of the calling file, loading all sibling files (but not the calling file itself) as command modules.

Any modules found must conform to minimal command module expectations before being added - that is the export must define either a `flags` or `aliases` property, or must be a function (interpreted as a `run` function, using the filename as the command alias). Any modules not conforming to this contract will be ignored.

If passed a directory that does not exist, the method will throw (synchronous configuration).

If a file (matching the necessary extensions) is found in the directory that cannot be loaded as a module via `require()`, the method will throw (synchronous configuration).