### PR TITLE
feat: support custom path and fs libs

### DIFF
--- a/api.js
+++ b/api.js
@@ -62,11 +62,11 @@ class Api {
   }
 
   newChild (commandName) {
-    // don't need from parent: types
-    // keep from parent: _factories, utils, name (plus command chain)
     return new Api({
       factories: this._factories,
       utils: this.utils,
+      pathLib: this.pathLib,
+      fsLib: this.fsLib,
       name: this.name + ' ' + commandName,
       parentName: this.name,
       modulesSeen: this._modulesSeen.slice(),
@@ -164,7 +164,10 @@ class Api {
   }
 
   getPath (opts) {
-    return require('./types/path').get(opts)
+    return require('./types/path').get(Object.assign({
+      pathLib: this.pathLib,
+      fsLib: this.fsLib
+    }, opts))
   }
 
   getFile (opts) {
@@ -664,7 +667,11 @@ class Api {
   }
 
   initContext (includeTypes) {
-    let context = this.get('_context', { utils: this.utils })
+    let context = this.get('_context', {
+      utils: this.utils,
+      pathLib: this.pathLib,
+      fsLib: this.fsLib
+    })
     return includeTypes ? this.applyTypes(context) : context
   }
 

--- a/context.js
+++ b/context.js
@@ -141,7 +141,7 @@ class Context {
 
   unexpectedError (err) {
     this.errors.push(err)
-    this.output = format(err)
+    this.output = String((err && err.stack) || err)
     this.code++
   }
 

--- a/types/path.js
+++ b/types/path.js
@@ -23,6 +23,10 @@ class TypePath extends TypeString {
     if (typeof override === 'undefined') override = true
     super.configure(opts, override)
 
+    // dependencies
+    if (override || !this._pathLib) this._pathLib = opts.pathLib || this._pathLib
+    if (override || !this._fsLib) this._fsLib = opts.fsLib || this._fsLib
+
     // booleans with a default value
     if (override || typeof this._dirAllowed === 'undefined') this._dirAllowed = 'dirAllowed' in opts ? opts.dirAllowed : this._dirAllowed
     if (override || typeof this._fileAllowed === 'undefined') this._fileAllowed = 'fileAllowed' in opts ? opts.fileAllowed : this._fileAllowed


### PR DESCRIPTION
Since the use of (customizable) path and fs libs were added to `Api` in #5, it seemed like a good idea to reuse those same libs throughout the framework. I'm hoping this will make sywac easier to use in non-Node.js environments.

This change replaces all typical uses of `require('path')` and `require('fs')` with injected dependencies, falling back to the standard Node.js libs in `Api` and propagating the lib references used by the top-level `Api` instance down to all child and factory-based instances.