### PR TITLE
chore: do not install latest npm on Node 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   - '6'
   - '4'
 before_install:
-  - ! [[ $(node -v) =~ ^v9.*$ ]] && npm install -g npm@latest
+  - '! [[ $(node -v) =~ ^v9.*$ ]] && npm install -g npm@latest'
   - npm install -g greenkeeper-lockfile@1
 before_script: greenkeeper-lockfile-update
 after_script: greenkeeper-lockfile-upload

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   - '6'
   - '4'
 before_install:
-  - '! [[ $(node -v) =~ ^v9.*$ ]] && npm install -g npm@latest'
+  - '[[ $(node -v) =~ ^v9.*$ ]] || npm install -g npm@latest'
   - npm install -g greenkeeper-lockfile@1
 before_script: greenkeeper-lockfile-update
 after_script: greenkeeper-lockfile-upload

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   - '6'
   - '4'
 before_install:
-  - npm install -g npm@latest
+  - ! [[ $(node -v) =~ ^v9.*$ ]] && npm install -g npm@latest
   - npm install -g greenkeeper-lockfile@1
 before_script: greenkeeper-lockfile-update
 after_script: greenkeeper-lockfile-upload


### PR DESCRIPTION
Apparently you need to use the bundled npm that comes with Node 9. This PR skips the `npm install -g npm@latest` step of the Travis `before_install` script when running Node 9. Let's see if this works.

See https://github.com/npm/npm/issues/19019 for other details.