### PR TITLE
fix: avoid infinite loop when single word in desc is too wide

### DIFF
--- a/buffer.js
+++ b/buffer.js
@@ -424,10 +424,11 @@ class Buffer {
     let ansiDiff
     let index
     let noAnsi
-    while (str) {
+    let attempts = 0
+    while (str && ++attempts <= 999) {
       noAnsi = this.utils.stripAnsi(str)
       index = noAnsi.length <= width ? width : this.lastIndexOfRegex(noAnsi, this.split, width)
-      if (index < 1) index = width
+      if (index < 1) index = Math.max(width, 1)
       // TODO this ain't cutting it for ansi reconstitution
       chunk = str.slice(0, index).trim()
       ansiDiff = chunk.length - this.utils.stripAnsi(chunk).length

--- a/buffer.js
+++ b/buffer.js
@@ -427,7 +427,7 @@ class Buffer {
     while (str) {
       noAnsi = this.utils.stripAnsi(str)
       index = noAnsi.length <= width ? width : this.lastIndexOfRegex(noAnsi, this.split, width)
-      if (index === -1) index = width
+      if (index < 1) index = width
       // TODO this ain't cutting it for ansi reconstitution
       chunk = str.slice(0, index).trim()
       ansiDiff = chunk.length - this.utils.stripAnsi(chunk).length

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -123,6 +123,23 @@ tap.test('api > help text with ANSI desc too wide (best effort)', t => {
   t.end()
 })
 
+// issue 21
+tap.test('api > help text with single word too wide in desc (best effort)', t => {
+  const helpText = Api.get()
+    .string('-s, --string <string>', {
+      desc: 'This used to cause an infinite loop in buffer\'s chunk method. See (https://documentation.mailgun.com/en/latest/user_manual.html#scheduling-delivery)'
+    })
+    .getHelp({ includeUsage: false })
+  t.equal(helpText, [
+    'Options:',
+    '  -s, --string <string>  This used to cause an infinite loop in buffer\'s chunk method. See',
+    '                         (https://documentation.mailgun.com/en/latest/user_manual.html#scheduling-d',
+    '                         elivery)',
+    '                         [string]'
+  ].join('\n'))
+  t.end()
+})
+
 tap.test('buffer > appendTypeSingleLine for type without helpFlags (not typically possible)', t => {
   const str = HelpBuffer.get().appendTypeSingleLine('', {
     helpDesc: 'desc',


### PR DESCRIPTION
Part of generating the help text includes splitting up descriptions into smaller chunks when the description is longer/wider than the space left (according to `maxWidth` of `.outputSettings()`).

The logic for doing this is not ideal, especially when it comes to strings with ANSI codes (like color), but it's implemented as a best effort. (The typical workaround is to use more than one pair of ANSI codes, to manually wrap each chunk in the description yourself.)

However, there was a bug in this logic that did not properly handle the case where a single word in the description (like a url) was longer than the allotted width. In this scenario, an infinite loop would occur during the chunking process, which would result in the application hanging until it eventually ran out of memory (due to an ever-growing array).

This PR fixes the logic to handle that particular use-case (including a new test), and it also introduces other safety measures to avoid an infinite loop even if the logic is faulty in other ways.

This was reported in issue #21. We will need to verify the fix there before we close the issue.