### PR TITLE
chore: fix tests since Node 12 release

### DIFF
--- a/context.js
+++ b/context.js
@@ -147,7 +147,20 @@ class Context {
 
   cliMessage (msg) {
     // do NOT modify this.code here - the messages will be disregarded if help is requested
-    this.messages.push(format.apply(null, arguments))
+    const argsLen = arguments.length
+    const args = new Array(argsLen - 1)
+    for (let i = 0; i < argsLen; ++i) {
+      args[i] = arguments[i]
+      // if any args are an array, join into string
+      // this is a hack to get Node 12's util.format working like Node 10's
+      // e.g. require('util').format("Value \"%s\" is invalid.", ["web", "docs"])
+      // Node 10: Value "web,docs" is invalid.
+      // Node 12: Value "[ 'web', 'docs' ]" is invalid.
+      if (Array.isArray(args[i])) {
+        args[i] = args[i].join(',')
+      }
+    }
+    this.messages.push(format.apply(null, args))
   }
 
   markTypeInvalid (id) {

--- a/test/fixture2/module.cjs
+++ b/test/fixture2/module.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  flags: 'module',
+  desc: 'A module with cjs file extension'
+}

--- a/test/fixture2/module.mjs
+++ b/test/fixture2/module.mjs
@@ -1,4 +1,0 @@
-module.exports = {
-  flags: 'module',
-  desc: 'A module with mjs file extension'
-}

--- a/test/fixture2/test-special.js
+++ b/test/fixture2/test-special.js
@@ -26,7 +26,7 @@ tap.test('commandDirectory > supports no arg (directory of caller)', t => {
 
 tap.test('commandDirectory > supports opts only', t => {
   return Api.get({ name: 'test' })
-    .commandDirectory({ extensions: ['.mjs'] })
+    .commandDirectory({ extensions: ['.cjs'] })
     .help()
     .outputSettings({ maxWidth: 50 })
     .parse('--help')
@@ -37,7 +37,7 @@ tap.test('commandDirectory > supports opts only', t => {
         'Usage: test <command> [options]',
         '',
         'Commands:',
-        '  module  A module with mjs file extension',
+        '  module  A module with cjs file extension',
         '',
         'Options:',
         '  --help  Show help     [commands: help] [boolean]'


### PR DESCRIPTION
Tests started failing when Node 12 was released. This was due to the following changes:

1. Node 12 now supports ESM by default via `.mjs` file extension

    Sywac was incorrectly using a CommonJS module with a `.mjs` file extension in a test for `commandDirectory()`. This was changed to use a `.cjs` file extension.

    **Note** that sywac does not currently support dynamic importing of ESM modules via `commandDirectory(dir)`. You can still import your ESM modules yourself and use `command(module)`.

2. Node 12 changed how `require('util').format()` handles/renders arrays.

    Sywac was relying on this functionality for building certain error messages. This was changed to detect array args and join them into a string instead of passing the array as-is.

This should fix CI and get sywac back on track for future updates.