### PR TITLE
chore: bump dev dependencies, July 2019 edition

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   },
   "homepage": "http://sywac.io",
   "devDependencies": {
-    "chalk": "^2.0.1",
-    "coveralls": "^3.0.0",
+    "chalk": "^2.4.2",
+    "coveralls": "^3.0.5",
     "del": "^3.0.0",
     "require-uncached": "^1.0.3",
     "standard": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "chalk": "^2.4.2",
     "coveralls": "^3.0.5",
     "del": "^3.0.0",
-    "require-uncached": "^1.0.3",
+    "import-fresh": "^3.1.0",
     "standard": "^11.0.0",
     "tap": "^12.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "chalk": "^2.4.2",
     "coveralls": "^3.0.5",
-    "del": "^3.0.0",
+    "del": "^5.0.0",
     "import-fresh": "^3.1.0",
     "standard": "^11.0.0",
     "tap": "^12.0.1"

--- a/test/test-index.js
+++ b/test/test-index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const tap = require('tap')
-const requireUncached = require('require-uncached')
+const importFresh = require('import-fresh')
 
 const TypeString = require('../types/string')
 const Utils = require('../lib/utils')
@@ -9,7 +9,7 @@ const Helper = require('./helper')
 
 tap.test('index > default singleton api', t => {
   const h = Helper.get('test-index')
-  const sywac = requireUncached('../index').string('-b, --branch <name>').boolean('-f, --force')
+  const sywac = importFresh('../index').string('-b, --branch <name>').boolean('-f, --force')
   return sywac.parse([]).then(result => {
     h.assertNoErrors(t, result)
     t.equal(result.argv.b, undefined)
@@ -50,7 +50,7 @@ tap.test('index > configured singleton api', t => {
 
   class CustomString extends TypeString { get datatype () { return 'custom' } }
 
-  return requireUncached('../index')
+  return importFresh('../index')
     .configure({
       name: name,
       utils: new CustomUtils(),


### PR DESCRIPTION
Gets everything to latest except `standard` and `tap` - I will do those separately since they will probably require more significant code changes.