### PR TITLE
chore: bump dev dependencies, March 2020 edition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 language: node_js
 node_js:
   - 'node'
+  - '12'
   - '10'
   - '8'
 after_success: npm run coverage

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "http://sywac.io",
   "devDependencies": {
-    "chalk": "^2.4.2",
+    "chalk": "^3.0.0",
     "coveralls": "^3.0.9",
     "del": "^5.1.0",
     "import-fresh": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
   "homepage": "http://sywac.io",
   "devDependencies": {
     "chalk": "^2.4.2",
-    "coveralls": "^3.0.5",
-    "del": "^5.0.0",
-    "import-fresh": "^3.1.0",
-    "standard": "^14.0.0",
-    "tap": "^14.4.3"
+    "coveralls": "^3.0.9",
+    "del": "^5.1.0",
+    "import-fresh": "^3.2.1",
+    "standard": "^14.3.2",
+    "tap": "^14.10.6"
   }
 }


### PR DESCRIPTION
Fixes #41. Fixes #44. Closes #43.

Explicitly bump all dev dependencies to latest version.

Bumps chalk major to v3, which requires Node 8+. Sywac had already dropped support for Node versions below 8, so this is fine.