### PR TITLE
Error on unknown options and arguments if specified

### DIFF
--- a/api.js
+++ b/api.js
@@ -62,8 +62,8 @@ class Api {
     return this
   }
 
-  newChild (commandName) {
-    return new Api({
+  newChild (commandName, childOptions) {
+    return new Api(Object.assign({
       factories: this._factories,
       utils: this.utils,
       pathLib: this.pathLib,
@@ -74,7 +74,7 @@ class Api {
       helpOpts: this._assignHelpOpts({}, this.helpOpts),
       showHelpByDefault: this._showHelpByDefault,
       strictMode: this._strictMode
-    })
+    }, childOptions))
   }
 
   _assignHelpOpts (target, source) {
@@ -656,7 +656,7 @@ class Api {
       this._magicCommandAdded = true
       this._internalCommand(Api.DEFAULT_COMMAND_INDICATOR, (argv, context) => {
         context.deferHelp().addDeferredHelp(this.initHelpBuffer())
-      }).configure({ api: this.newChild(Api.DEFAULT_COMMAND_INDICATOR) }, false)
+      }).configure({ api: this.newChild(Api.DEFAULT_COMMAND_INDICATOR, { strictMode: false }) }, false)
     }
 
     // add known types to context

--- a/api.js
+++ b/api.js
@@ -37,6 +37,7 @@ class Api {
       commandType: this.getCommand
     }
     this._showHelpByDefault = 'showHelpByDefault' in opts ? opts.showHelpByDefault : false
+    this._strictMode = 'strictMode' in opts ? opts.strictMode : false
     this._magicCommandAdded = false
     this._modulesSeen = opts.modulesSeen || []
     this.configure(opts)
@@ -71,7 +72,8 @@ class Api {
       parentName: this.name,
       modulesSeen: this._modulesSeen.slice(),
       helpOpts: this._assignHelpOpts({}, this.helpOpts),
-      showHelpByDefault: this._showHelpByDefault
+      showHelpByDefault: this._showHelpByDefault,
+      strictMode: this._strictMode
     })
   }
 
@@ -282,6 +284,24 @@ class Api {
   showHelpByDefault (boolean) {
     this._showHelpByDefault = boolean !== false
     return this
+  }
+
+  strict (boolean) {
+    this._strictMode = boolean !== false
+    return this
+  }
+
+  addStrictModeErrors (context) {
+    if (this._strictMode) {
+      const unknownOptions = context.getUnknownSlurpedOptions()
+      if (unknownOptions.length > 0) {
+        context.cliMessage(`Unknown options: ${unknownOptions.map(u => u.raw).join(', ')}`)
+      }
+      const unknownArguments = context.getUnknownArguments()
+      if (unknownArguments.length > 0) {
+        context.cliMessage(`Unknown arguments: ${unknownArguments.join(' ')}`)
+      }
+    }
   }
 
   // complex types
@@ -597,6 +617,10 @@ class Api {
     if (this._showHelpByDefault && !context.details.args.length) context.deferHelp() // preemptively request help
 
     return this.parseFromContext(context).then(whenDone => {
+      if (!context.commandHandlerRun && !context.output) {
+        this.addStrictModeErrors(context)
+      }
+
       if (context.helpRequested && !context.output) {
         context.addDeferredHelp(this.initHelpBuffer())
       } else if (context.versionRequested && !context.output) {

--- a/context.js
+++ b/context.js
@@ -306,16 +306,14 @@ class Context {
   }
 
   getUnknownArguments () {
-    return this.argv._
+    if (!Array.isArray(this.argv._)) return []
+    const endOptions = this.argv._.indexOf('--')
+    return this.argv._.slice(0, endOptions === -1 ? this.argv._.length : endOptions)
   }
 
   getUnknownSlurpedOptions () {
-    const known = Object.keys(this.knownArgv)
-    const provided = Object.keys(this.argv)
-    const unknown = provided.filter(key => !known.includes(key))
-
-    return unknown.map(key => {
-      return this.slurped.find(arg => arg.parsed.find(p => p.key === key))
+    return Object.keys(this.argv).filter(key => !(key in this.knownArgv)).map(key => {
+      return this.slurped.find(arg => arg.parsed.some(p => p.key === key))
     })
   }
 

--- a/context.js
+++ b/context.js
@@ -25,6 +25,7 @@ class Context {
     this.code = 0
     this.output = ''
     this.argv = {}
+    this.knownArgv = {}
     this.details = { args: [], types: [] }
     this.errors = []
     this.messages = []
@@ -299,7 +300,22 @@ class Context {
       if (tr.datatype === 'command') return undefined // do not add command aliases to argv
       tr.aliases.forEach(alias => {
         this.argv[alias] = tr.value
+        this.knownArgv[alias] = tr.value
       })
+    })
+  }
+
+  getUnknownArguments () {
+    return this.argv._
+  }
+
+  getUnknownSlurpedOptions () {
+    const known = Object.keys(this.knownArgv)
+    const provided = Object.keys(this.argv)
+    const unknown = provided.filter(key => !known.includes(key))
+
+    return unknown.map(key => {
+      return this.slurped.find(arg => arg.parsed.find(p => p.key === key))
     })
   }
 

--- a/test/test-parse.js
+++ b/test/test-parse.js
@@ -262,6 +262,80 @@ tap.test('parse > strict mode prevents unknown options and arguments in command 
   })
 })
 
+tap.test('parse > strict mode still allows showHelpByDefault to work', t => {
+  let ranCommand = false
+  const api = Api.get({ name: 'program' })
+    .string('-n, --name <string>')
+    .number('-a, --age <number>')
+    .command('send <studentid>', argv => {
+      ranCommand = true
+    })
+    .strict()
+    .showHelpByDefault()
+    .outputSettings({ maxWidth: 41 })
+  return api.parse('').then(result => {
+    t.equal(result.code, 0)
+    t.equal(result.errors.length, 0)
+    t.equal(result.output, [
+      'Usage: program <command> <args> [options]',
+      '',
+      'Commands:',
+      '  send <studentid>',
+      '',
+      'Options:',
+      '  -n, --name <string>            [string]',
+      '  -a, --age <number>             [number]'
+    ].join('\n'))
+    t.equal(ranCommand, false)
+    return api.parse('send 111 222 --nmae Fred --age 24')
+  }).then(result => {
+    t.equal(result.code, 2)
+    t.equal(result.errors.length, 0)
+    t.equal(result.output, [
+      'Usage: program send <studentid> [options]',
+      '',
+      'Arguments:',
+      '  <studentid>         [required] [string]',
+      '',
+      'Options:',
+      '  -n, --name <string>            [string]',
+      '  -a, --age <number>             [number]',
+      '',
+      'Unknown options: --nmae',
+      'Unknown arguments: 222'
+    ].join('\n'))
+    t.equal(ranCommand, false)
+    return api.parse('send 111 --name Fred --age 24')
+  }).then(result => {
+    t.equal(result.code, 0)
+    t.equal(ranCommand, true)
+  })
+})
+
+tap.test('parse > strict mode ignores options/arguments after --', t => {
+  let commandArguments
+  const api = Api.get()
+    .string('-n, --name <string>')
+    .number('-a, --age <number>')
+    .command('send <studentid>', argv => {
+      commandArguments = argv._
+    })
+    .strict()
+  return api.parse('send 111 -n Fred --aeg 24 222 -- 333 --force').then(result => {
+    t.equal(result.code, 2)
+    t.match(result.output, /Unknown options: --aeg/)
+    t.match(result.output, /Unknown arguments: 222/)
+    t.equal(result.errors.length, 0)
+    t.equal(commandArguments, undefined)
+    return api.parse('send 111 -n Fred --age 24 -- 222 333 --force')
+  }).then(result => {
+    t.equal(result.code, 0)
+    t.equal(result.errors.length, 0)
+    t.equal(result.output, '')
+    t.strictSame(commandArguments, ['--', '222', '333', '--force'])
+  })
+})
+
 tap.test('parse > coerced types', t => {
   const promises = []
 

--- a/test/test-parse.js
+++ b/test/test-parse.js
@@ -250,7 +250,7 @@ tap.test('parse > strict mode prevents unknown options and arguments in command 
     t.equal(result.errors.length, 0)
     return api.parse('send 111 222 333 --hello')
   }).then(result => {
-    t.equal(result.code, 1)
+    t.equal(result.code, 2)
     t.match(result.output, /Unknown arguments: 222 333/)
     t.match(result.output, /Unknown options: --hello/)
     t.equal(result.errors.length, 0)

--- a/types/command.js
+++ b/types/command.js
@@ -122,6 +122,7 @@ class TypeCommand extends Type {
       // only run innermost command handler
       if (context.commandHandlerRun) return this.resolve()
       context.commandHandlerRun = true
+      this.api.addStrictModeErrors(context)
       if (context.helpRequested || context.messages.length) {
         // console.log('command.js postParse > adding deferred help, implicit:', match.implicit)
         if (!context.output) context.addDeferredHelp(this.api.initHelpBuffer())


### PR DESCRIPTION
### SUMMARY

Allow program to specify that unknown arguments and options should result in an error.

### DETAILS

My approach here is to use (assume?) that any slurped arguments that aren't claimed are unknown arguments.  The check is made either (1) right before we call the run handler on the innermost command, or (2) when we're ready to return from `parse`, if no command was run.

I copied commander's interface here and used `allowUnknown(true/false)`, although of course the default is true instead of commander's default of false.  The boolean could easily be flipped and called `preventUnknown` or `errorOnUnknown` instead.

In my testing on my local copy, this approach seems to give the desired nesting behavior (you can specify `.allowUnknown(false)` in your top-level CLI as you define all your commands and get it everywhere, or you can specify it in the `setup` of just one command, if you don't want the behavior everywhere).

### TESTS

I didn't add any unit tests yet, but am happy to if this approach looks reasonable and you'd want to merge it!
