### PR TITLE
refactor: migrate codebase to use async/await

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,20 +38,23 @@ Then create a `cli.js` file with code similar to this:
 
 ```js
 #!/usr/bin/env node
-'use strict'
 
-require('sywac')
-  .positional('<string>', { paramsDesc: 'A required string argument' })
-  .boolean('-b, --bool', { desc: 'A boolean option' })
-  .number('-n, --num <number>', { desc: 'A number option' })
-  .help('-h, --help')
-  .version('-v, --version')
-  .showHelpByDefault()
-  .outputSettings({ maxWidth: 75 })
-  .parseAndExit()
-  .then(argv => {
-    console.log(JSON.stringify(argv, null, 2))
-  })
+const sywac = require('sywac')
+
+async function main () {
+  const argv = await sywac
+    .positional('<string>', { paramsDesc: 'A required string argument' })
+    .boolean('-b, --bool', { desc: 'A boolean option' })
+    .number('-n, --num <number>', { desc: 'A number option' })
+    .help('-h, --help')
+    .version('-v, --version')
+    .showHelpByDefault()
+    .outputSettings({ maxWidth: 75 })
+    .parseAndExit()
+  console.log(JSON.stringify(argv, null, 2))
+}
+
+main()
 ```
 
 Make the `cli.js` file executable:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "coverage": "nyc report --reporter=text-lcov | coveralls"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "repository": {
     "type": "git",

--- a/test/fixture/ndb.js
+++ b/test/fixture/ndb.js
@@ -41,5 +41,10 @@ sywac
   .usage({ prefix: chalk`{white Usage:} {magenta $0}` })
   .outputSettings({ maxWidth: 90 })
 
-// only prints argv if a command handler was run
-sywac.parseAndExit().then(argv => console.log(JSON.stringify(argv, null, 2)))
+async function main () {
+  // only prints argv if a command handler was run
+  const argv = await sywac.parseAndExit()
+  console.log(JSON.stringify(argv, null, 2))
+}
+
+main()

--- a/test/fixture2/test-special.js
+++ b/test/fixture2/test-special.js
@@ -3,44 +3,40 @@
 const tap = require('tap')
 const Api = require('../../api')
 
-tap.test('commandDirectory > supports no arg (directory of caller)', t => {
-  return Api.get({ name: 'test' })
+tap.test('commandDirectory > supports no arg (directory of caller)', async t => {
+  const result = await Api.get({ name: 'test' })
     .commandDirectory()
     .help()
     .outputSettings({ maxWidth: 50 })
     .parse('--help')
-    .then(result => {
-      t.equal(result.code, 0)
-      t.equal(result.errors.length, 0)
-      t.equal(result.output, [
-        'Usage: test <command> <args> [options]',
-        '',
-        'Commands:',
-        '  random [max=1] [min=0]  Get pseudo-random number',
-        '',
-        'Options:',
-        '  --help  Show help     [commands: help] [boolean]'
-      ].join('\n'))
-    })
+  t.equal(result.code, 0)
+  t.equal(result.errors.length, 0)
+  t.equal(result.output, [
+    'Usage: test <command> <args> [options]',
+    '',
+    'Commands:',
+    '  random [max=1] [min=0]  Get pseudo-random number',
+    '',
+    'Options:',
+    '  --help  Show help     [commands: help] [boolean]'
+  ].join('\n'))
 })
 
-tap.test('commandDirectory > supports opts only', t => {
-  return Api.get({ name: 'test' })
+tap.test('commandDirectory > supports opts only', async t => {
+  const result = await Api.get({ name: 'test' })
     .commandDirectory({ extensions: ['.cjs'] })
     .help()
     .outputSettings({ maxWidth: 50 })
     .parse('--help')
-    .then(result => {
-      t.equal(result.code, 0)
-      t.equal(result.errors.length, 0)
-      t.equal(result.output, [
-        'Usage: test <command> [options]',
-        '',
-        'Commands:',
-        '  module  A module with cjs file extension',
-        '',
-        'Options:',
-        '  --help  Show help     [commands: help] [boolean]'
-      ].join('\n'))
-    })
+  t.equal(result.code, 0)
+  t.equal(result.errors.length, 0)
+  t.equal(result.output, [
+    'Usage: test <command> [options]',
+    '',
+    'Commands:',
+    '  module  A module with cjs file extension',
+    '',
+    'Options:',
+    '  --help  Show help     [commands: help] [boolean]'
+  ].join('\n'))
 })

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -205,7 +205,7 @@ tap.test('api > attempt to get unmapped type returns null (don\'t do this)', t =
   t.end()
 })
 
-tap.test('api > custom path and fs libs', t => {
+tap.test('api > custom path and fs libs', async t => {
   class FakePath {
     // used by api
     basename () {
@@ -271,27 +271,27 @@ tap.test('api > custom path and fs libs', t => {
 
   const promises = []
 
-  promises.push(api.parse('-p anything').then(result => {
-    t.equal(result.code, 0)
-    t.equal(result.output, '')
-    t.equal(result.errors.length, 0)
-    t.equal(result.argv.p, 'anything')
-  }))
+  promises.push(api.parse('-p anything'))
 
-  promises.push(api.parse('--version').then(result => {
-    t.equal(result.code, 0)
-    t.equal(result.output, '0.0.0-custom')
-    t.equal(result.errors.length, 0)
-  }))
+  promises.push(api.parse('--version'))
 
-  return Promise.all(promises).then(whenDone => {
-    t.equal(pathLib.basenameCalled, 1)
-    t.equal(pathLib.isAbsoluteCalled, 1)
-    t.equal(pathLib.dirnameCalled, 1)
-    t.equal(pathLib.parseCalled, 1)
-    t.equal(pathLib.joinCalled, 1)
-    t.equal(fsLib.readdirSyncCalled, 1)
-    t.equal(fsLib.statCalled, 1)
-    t.equal(fsLib.readFileSyncCalled, 1)
-  })
+  const [result1, result2] = await Promise.all(promises)
+
+  t.equal(result1.code, 0)
+  t.equal(result1.output, '')
+  t.equal(result1.errors.length, 0)
+  t.equal(result1.argv.p, 'anything')
+
+  t.equal(result2.code, 0)
+  t.equal(result2.output, '0.0.0-custom')
+  t.equal(result2.errors.length, 0)
+
+  t.equal(pathLib.basenameCalled, 1)
+  t.equal(pathLib.isAbsoluteCalled, 1)
+  t.equal(pathLib.dirnameCalled, 1)
+  t.equal(pathLib.parseCalled, 1)
+  t.equal(pathLib.joinCalled, 1)
+  t.equal(fsLib.readdirSyncCalled, 1)
+  t.equal(fsLib.statCalled, 1)
+  t.equal(fsLib.readFileSyncCalled, 1)
 })

--- a/test/test-command-directory.js
+++ b/test/test-command-directory.js
@@ -4,7 +4,7 @@ const tap = require('tap')
 const Api = require('../api')
 const path = require('path')
 
-tap.test('commandDirectory > supports multi-level', t => {
+tap.test('commandDirectory > supports multi-level', async t => {
   const api = Api.get({ name: 'test' })
     .commandDirectory('fixture2/level1')
     .showHelpByDefault()
@@ -12,98 +12,93 @@ tap.test('commandDirectory > supports multi-level', t => {
 
   const promises = []
 
-  promises.push(api.parse('').then(result => {
-    t.equal(result.code, 0)
-    t.equal(result.errors.length, 0)
-    t.equal(result.output, [
-      'Usage: test <command> <args>',
-      '',
-      'Commands:',
-      '  one <subcommand>  Level one command',
-      '  top             '
-    ].join('\n'))
-  }))
+  promises.push(api.parse(''))
+  promises.push(api.parse('one'))
+  promises.push(api.parse('one two'))
+  promises.push(api.parse('one two three'))
 
-  promises.push(api.parse('one').then(result => {
-    t.equal(result.code, 0)
-    t.equal(result.errors.length, 0)
-    t.equal(result.output, [
-      'Usage: test one <subcommand>',
-      '',
-      'Commands:',
-      '  two <subcommand>  Level two command'
-    ].join('\n'))
-  }))
+  const [result1, result2, result3, result4] = await Promise.all(promises)
 
-  promises.push(api.parse('one two').then(result => {
-    t.equal(result.code, 0)
-    t.equal(result.errors.length, 0)
-    t.equal(result.output, [
-      'Usage: test one two <subcommand>',
-      '',
-      'Commands:',
-      '  three  Level three command'
-    ].join('\n'))
-  }))
+  t.equal(result1.code, 0)
+  t.equal(result1.errors.length, 0)
+  t.equal(result1.output, [
+    'Usage: test <command> <args>',
+    '',
+    'Commands:',
+    '  one <subcommand>  Level one command',
+    '  top             '
+  ].join('\n'))
 
-  promises.push(api.parse('one two three').then(result => {
-    t.equal(result.code, 0)
-    t.equal(result.errors.length, 0)
-    t.equal(result.output, '')
-    t.equal(result.argv.threeRun, true)
-  }))
+  t.equal(result2.code, 0)
+  t.equal(result2.errors.length, 0)
+  t.equal(result2.output, [
+    'Usage: test one <subcommand>',
+    '',
+    'Commands:',
+    '  two <subcommand>  Level two command'
+  ].join('\n'))
 
-  return Promise.all(promises)
+  t.equal(result3.code, 0)
+  t.equal(result3.errors.length, 0)
+  t.equal(result3.output, [
+    'Usage: test one two <subcommand>',
+    '',
+    'Commands:',
+    '  three  Level three command'
+  ].join('\n'))
+
+  t.equal(result4.code, 0)
+  t.equal(result4.errors.length, 0)
+  t.equal(result4.output, '')
+  t.equal(result4.argv.threeRun, true)
 })
 
-tap.test('commandDirectory > supports absolute', t => {
+tap.test('commandDirectory > supports absolute', async t => {
   const absolutePath = path.join(__dirname, 'fixture2', 'level1')
-  return Api.get({ name: 'test' })
+  const result = await Api.get({ name: 'test' })
     .commandDirectory(absolutePath)
     .showHelpByDefault()
     .outputSettings({ maxWidth: 50 })
     .parse('')
-    .then(result => {
-      t.equal(result.code, 0)
-      t.equal(result.errors.length, 0)
-      t.equal(result.output, [
-        'Usage: test <command> <args>',
-        '',
-        'Commands:',
-        '  one <subcommand>  Level one command',
-        '  top             '
-      ].join('\n'))
-    })
+  t.equal(result.code, 0)
+  t.equal(result.errors.length, 0)
+  t.equal(result.output, [
+    'Usage: test <command> <args>',
+    '',
+    'Commands:',
+    '  one <subcommand>  Level one command',
+    '  top             '
+  ].join('\n'))
 })
 
-tap.test('commandDirectory > detects and ignores cyclic reference', t => {
+tap.test('commandDirectory > detects and ignores cyclic reference', async t => {
   const api = Api.get({ name: 'test' })
     .commandDirectory('fixture2/cyclic')
     .help()
     .outputSettings({ maxWidth: 50 })
-  return api.parse('--help').then(result => {
-    t.equal(result.code, 0)
-    t.equal(result.errors.length, 0)
-    t.equal(result.output, [
-      'Usage: test <command> [options]',
-      '',
-      'Commands:',
-      '  command  Attempts to (re)apply its own dir',
-      '',
-      'Options:',
-      '  --help  Show help     [commands: help] [boolean]'
-    ].join('\n'))
-    return api.parse('command --help')
-  }).then(result => {
-    t.equal(result.code, 0)
-    t.equal(result.errors.length, 0)
-    t.equal(result.output, [
-      'Usage: test command [options]',
-      '',
-      'Options:',
-      '  --help  Show help     [commands: help] [boolean]'
-    ].join('\n'))
-  })
+
+  let result = await api.parse('--help')
+  t.equal(result.code, 0)
+  t.equal(result.errors.length, 0)
+  t.equal(result.output, [
+    'Usage: test <command> [options]',
+    '',
+    'Commands:',
+    '  command  Attempts to (re)apply its own dir',
+    '',
+    'Options:',
+    '  --help  Show help     [commands: help] [boolean]'
+  ].join('\n'))
+
+  result = await api.parse('command --help')
+  t.equal(result.code, 0)
+  t.equal(result.errors.length, 0)
+  t.equal(result.output, [
+    'Usage: test command [options]',
+    '',
+    'Options:',
+    '  --help  Show help     [commands: help] [boolean]'
+  ].join('\n'))
 })
 
 tap.test('commandDirectory > throws on missing directory', t => {

--- a/test/test-index.js
+++ b/test/test-index.js
@@ -7,36 +7,35 @@ const TypeString = require('../types/string')
 const Utils = require('../lib/utils')
 const Helper = require('./helper')
 
-tap.test('index > default singleton api', t => {
+tap.test('index > default singleton api', async t => {
   const h = Helper.get('test-index')
   const sywac = importFresh('../index').string('-b, --branch <name>').boolean('-f, --force')
-  return sywac.parse([]).then(result => {
-    h.assertNoErrors(t, result)
-    t.equal(result.argv.b, undefined)
-    t.equal(result.argv.branch, undefined)
-    t.equal(result.argv.f, false)
-    t.equal(result.argv.force, false)
-    t.same(result.argv._, [])
-    t.equal(Object.keys(result.argv).length, 5)
-    h.assertTypeDetails(t, result, 0, ['_'], 'array:string', [], 'default', [], [])
-    h.assertTypeDetails(t, result, 1, ['b', 'branch'], 'string', undefined, 'default', [], [])
-    h.assertTypeDetails(t, result, 2, ['f', 'force'], 'boolean', false, 'default', [], [])
-    return sywac.parse(['-fb', 'master'])
-  }).then(result => {
-    h.assertNoErrors(t, result)
-    t.equal(result.argv.b, 'master')
-    t.equal(result.argv.branch, 'master')
-    t.equal(result.argv.f, true)
-    t.equal(result.argv.force, true)
-    t.same(result.argv._, [])
-    t.equal(Object.keys(result.argv).length, 5)
-    h.assertTypeDetails(t, result, 0, ['_'], 'array:string', [], 'default', [], [])
-    h.assertTypeDetails(t, result, 1, ['b', 'branch'], 'string', 'master', 'flag', [0, 1], ['-fb', 'master'])
-    h.assertTypeDetails(t, result, 2, ['f', 'force'], 'boolean', true, 'flag', [0], ['-fb'])
-  })
+  let result = await sywac.parse([])
+  h.assertNoErrors(t, result)
+  t.equal(result.argv.b, undefined)
+  t.equal(result.argv.branch, undefined)
+  t.equal(result.argv.f, false)
+  t.equal(result.argv.force, false)
+  t.same(result.argv._, [])
+  t.equal(Object.keys(result.argv).length, 5)
+  h.assertTypeDetails(t, result, 0, ['_'], 'array:string', [], 'default', [], [])
+  h.assertTypeDetails(t, result, 1, ['b', 'branch'], 'string', undefined, 'default', [], [])
+  h.assertTypeDetails(t, result, 2, ['f', 'force'], 'boolean', false, 'default', [], [])
+
+  result = await sywac.parse(['-fb', 'master'])
+  h.assertNoErrors(t, result)
+  t.equal(result.argv.b, 'master')
+  t.equal(result.argv.branch, 'master')
+  t.equal(result.argv.f, true)
+  t.equal(result.argv.force, true)
+  t.same(result.argv._, [])
+  t.equal(Object.keys(result.argv).length, 5)
+  h.assertTypeDetails(t, result, 0, ['_'], 'array:string', [], 'default', [], [])
+  h.assertTypeDetails(t, result, 1, ['b', 'branch'], 'string', 'master', 'flag', [0, 1], ['-fb', 'master'])
+  h.assertTypeDetails(t, result, 2, ['f', 'force'], 'boolean', true, 'flag', [0], ['-fb'])
 })
 
-tap.test('index > configured singleton api', t => {
+tap.test('index > configured singleton api', async t => {
   const name = 'happy'
   const h = Helper.get(name)
 
@@ -50,7 +49,7 @@ tap.test('index > configured singleton api', t => {
 
   class CustomString extends TypeString { get datatype () { return 'custom' } }
 
-  return importFresh('../index')
+  const result = await importFresh('../index')
     .configure({
       name: name,
       utils: new CustomUtils(),
@@ -59,17 +58,17 @@ tap.test('index > configured singleton api', t => {
       }
     })
     .string('-s, --string <str>').boolean('-b, --bool')
-    .parse('--string=value --bool one').then(result => {
-      h.assertNoErrors(t, result)
-      t.equal(result.argv.s, 'value')
-      t.equal(result.argv.string, 'value')
-      t.equal(result.argv.b, true)
-      t.equal(result.argv.bool, true)
-      t.same(result.argv._, ['one'])
-      t.equal(Object.keys(result.argv).length, 5)
-      t.equal(customUtilsCalled, true)
-      h.assertTypeDetails(t, result, 1, ['s', 'string'], 'custom', 'value', 'flag', [0], ['--string=value'])
-      h.assertTypeDetails(t, result, 2, ['b', 'bool'], 'boolean', true, 'flag', [1], ['--bool'])
-      Helper.get(require('path').basename(__filename, '.js')).assertTypeDetails(t, result, 0, ['_'], 'array:string', ['one'], 'positional', [2], ['one'])
-    })
+    .parse('--string=value --bool one')
+
+  h.assertNoErrors(t, result)
+  t.equal(result.argv.s, 'value')
+  t.equal(result.argv.string, 'value')
+  t.equal(result.argv.b, true)
+  t.equal(result.argv.bool, true)
+  t.same(result.argv._, ['one'])
+  t.equal(Object.keys(result.argv).length, 5)
+  t.equal(customUtilsCalled, true)
+  h.assertTypeDetails(t, result, 1, ['s', 'string'], 'custom', 'value', 'flag', [0], ['--string=value'])
+  h.assertTypeDetails(t, result, 2, ['b', 'bool'], 'boolean', true, 'flag', [1], ['--bool'])
+  Helper.get(require('path').basename(__filename, '.js')).assertTypeDetails(t, result, 0, ['_'], 'array:string', ['one'], 'positional', [2], ['one'])
 })

--- a/test/test-parse.js
+++ b/test/test-parse.js
@@ -11,27 +11,26 @@ const helper = require('./helper').get(parent)
 const assertNoErrors = helper.assertNoErrors.bind(helper)
 const assertTypeDetails = helper.assertTypeDetails.bind(helper)
 
-tap.test('parse > no explicit types', t => {
-  return Api.get().parse('-xyz hello  there --xyz friend ------a=nice to see -u').then(result => {
-    assertNoErrors(t, result)
+tap.test('parse > no explicit types', async t => {
+  const result = await Api.get().parse('-xyz hello  there --xyz friend ------a=nice to see -u')
+  assertNoErrors(t, result)
 
-    t.same(result.argv._, ['there', 'to', 'see'])
-    t.equal(result.argv.x, true)
-    t.equal(result.argv.y, true)
-    t.equal(result.argv.z, 'hello')
-    t.equal(result.argv.xyz, 'friend')
-    t.equal(result.argv.a, 'nice')
-    t.equal(result.argv.u, true)
+  t.same(result.argv._, ['there', 'to', 'see'])
+  t.equal(result.argv.x, true)
+  t.equal(result.argv.y, true)
+  t.equal(result.argv.z, 'hello')
+  t.equal(result.argv.xyz, 'friend')
+  t.equal(result.argv.a, 'nice')
+  t.equal(result.argv.u, true)
 
-    t.same(result.details.args, ['-xyz', 'hello', 'there', '--xyz', 'friend', '------a=nice', 'to', 'see', '-u'])
+  t.same(result.details.args, ['-xyz', 'hello', 'there', '--xyz', 'friend', '------a=nice', 'to', 'see', '-u'])
 
-    t.equal(result.details.types.length, 1)
+  t.equal(result.details.types.length, 1)
 
-    assertTypeDetails(t, result, 0, ['_'], 'array:string', ['there', 'to', 'see'], 'positional', [2, 6, 7], ['there', 'to', 'see'])
-  })
+  assertTypeDetails(t, result, 0, ['_'], 'array:string', ['there', 'to', 'see'], 'positional', [2, 6, 7], ['there', 'to', 'see'])
 })
 
-tap.test('parse > dashes allowed as unknown args', t => {
+tap.test('parse > dashes allowed as unknown args', async t => {
   class Counter extends Context {
     constructor (opts) {
       super(opts)
@@ -44,29 +43,29 @@ tap.test('parse > dashes allowed as unknown args', t => {
     }
   }
   let counter
-  return Api.get()
+  const result = await Api.get()
     .registerFactory('_context', opts => new Counter(opts))
     .check((argv, context) => {
       counter = context
     })
-    .parse('- --- ---- -- -').then(result => {
-      assertNoErrors(t, result)
+    .parse('- --- ---- -- -')
 
-      t.equal(counter.numParseableArgs, 3)
+  assertNoErrors(t, result)
 
-      t.same(result.argv._, ['-', '---', '----', '--', '-'])
-      t.equal(Object.keys(result.argv).length, 1)
+  t.equal(counter.numParseableArgs, 3)
 
-      t.same(result.details.args, ['-', '---', '----', '--', '-'])
+  t.same(result.argv._, ['-', '---', '----', '--', '-'])
+  t.equal(Object.keys(result.argv).length, 1)
 
-      t.equal(result.details.types.length, 1)
+  t.same(result.details.args, ['-', '---', '----', '--', '-'])
 
-      assertTypeDetails(t, result, 0, ['_'], 'array:string', ['-', '---', '----', '--', '-'], 'positional', [0, 1, 2, 3, 4], ['-', '---', '----', '--', '-'])
-    })
+  t.equal(result.details.types.length, 1)
+
+  assertTypeDetails(t, result, 0, ['_'], 'array:string', ['-', '---', '----', '--', '-'], 'positional', [0, 1, 2, 3, 4], ['-', '---', '----', '--', '-'])
 })
 
-tap.test('parse > basic types', t => {
-  return Api.get()
+tap.test('parse > basic types', async t => {
+  const result = await Api.get()
     .boolean('-b, --bool')
     .enumeration('-e, --enum <choice>', {
       choices: ['one', 'two', 'three']
@@ -77,117 +76,117 @@ tap.test('parse > basic types', t => {
     .dir('-d, --dir <dir>')
     .string('-s, --string <str>')
     .parse('-b a --enum two b -n 0 c --path=local d e -f package.json f g --dir node_modules h -s "hello there" i')
-    .then(result => {
-      assertNoErrors(t, result)
 
-      t.same(result.argv._, ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'])
-      t.equal(result.argv.b, true)
-      t.equal(result.argv.bool, true)
-      t.notOk(result.argv.choice)
-      t.equal(result.argv.e, 'two')
-      t.equal(result.argv.enum, 'two')
-      t.equal(result.argv.n, 0)
-      t.equal(result.argv.number, 0)
-      t.notOk(result.argv.num)
-      t.equal(result.argv.p, 'local')
-      t.equal(result.argv.path, 'local')
-      t.equal(result.argv.f, 'package.json')
-      t.equal(result.argv.file, 'package.json')
-      t.equal(result.argv.d, 'node_modules')
-      t.equal(result.argv.dir, 'node_modules')
-      t.equal(result.argv.s, 'hello there')
-      t.equal(result.argv.string, 'hello there')
-      t.notOk(result.argv.str)
+  assertNoErrors(t, result)
 
-      t.same(result.details.args, [
-        '-b', 'a', '--enum', 'two', 'b', '-n', '0', 'c', '--path=local', 'd',
-        'e', '-f', 'package.json', 'f', 'g', '--dir', 'node_modules', 'h',
-        '-s', 'hello there', 'i'
-      ])
+  t.same(result.argv._, ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'])
+  t.equal(result.argv.b, true)
+  t.equal(result.argv.bool, true)
+  t.notOk(result.argv.choice)
+  t.equal(result.argv.e, 'two')
+  t.equal(result.argv.enum, 'two')
+  t.equal(result.argv.n, 0)
+  t.equal(result.argv.number, 0)
+  t.notOk(result.argv.num)
+  t.equal(result.argv.p, 'local')
+  t.equal(result.argv.path, 'local')
+  t.equal(result.argv.f, 'package.json')
+  t.equal(result.argv.file, 'package.json')
+  t.equal(result.argv.d, 'node_modules')
+  t.equal(result.argv.dir, 'node_modules')
+  t.equal(result.argv.s, 'hello there')
+  t.equal(result.argv.string, 'hello there')
+  t.notOk(result.argv.str)
 
-      t.equal(result.details.types.length, 8)
+  t.same(result.details.args, [
+    '-b', 'a', '--enum', 'two', 'b', '-n', '0', 'c', '--path=local', 'd',
+    'e', '-f', 'package.json', 'f', 'g', '--dir', 'node_modules', 'h',
+    '-s', 'hello there', 'i'
+  ])
 
-      assertTypeDetails(t, result,
-        0, ['_'], 'array:string',
-        ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'],
-        'positional',
-        [1, 4, 7, 9, 10, 13, 14, 17, 20],
-        ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']
-      )
-      assertTypeDetails(t, result, 1, ['b', 'bool'], 'boolean', true, 'flag', [0], ['-b'])
-      assertTypeDetails(t, result, 2, ['e', 'enum'], 'enum', 'two', 'flag', [2, 3], ['--enum', 'two'])
-      assertTypeDetails(t, result, 3, ['n', 'number'], 'number', 0, 'flag', [5, 6], ['-n', '0'])
-      assertTypeDetails(t, result, 4, ['p', 'path'], 'path', 'local', 'flag', [8], ['--path=local'])
-      assertTypeDetails(t, result, 5, ['f', 'file'], 'file', 'package.json', 'flag', [11, 12], ['-f', 'package.json'])
-      assertTypeDetails(t, result, 6, ['d', 'dir'], 'dir', 'node_modules', 'flag', [15, 16], ['--dir', 'node_modules'])
-      assertTypeDetails(t, result, 7, ['s', 'string'], 'string', 'hello there', 'flag', [18, 19], ['-s', 'hello there'])
-    })
+  t.equal(result.details.types.length, 8)
+
+  assertTypeDetails(t, result,
+    0, ['_'], 'array:string',
+    ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'],
+    'positional',
+    [1, 4, 7, 9, 10, 13, 14, 17, 20],
+    ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']
+  )
+  assertTypeDetails(t, result, 1, ['b', 'bool'], 'boolean', true, 'flag', [0], ['-b'])
+  assertTypeDetails(t, result, 2, ['e', 'enum'], 'enum', 'two', 'flag', [2, 3], ['--enum', 'two'])
+  assertTypeDetails(t, result, 3, ['n', 'number'], 'number', 0, 'flag', [5, 6], ['-n', '0'])
+  assertTypeDetails(t, result, 4, ['p', 'path'], 'path', 'local', 'flag', [8], ['--path=local'])
+  assertTypeDetails(t, result, 5, ['f', 'file'], 'file', 'package.json', 'flag', [11, 12], ['-f', 'package.json'])
+  assertTypeDetails(t, result, 6, ['d', 'dir'], 'dir', 'node_modules', 'flag', [15, 16], ['--dir', 'node_modules'])
+  assertTypeDetails(t, result, 7, ['s', 'string'], 'string', 'hello there', 'flag', [18, 19], ['-s', 'hello there'])
 })
 
-tap.test('parse > multiple sequential passes', t => {
+tap.test('parse > multiple sequential passes', async t => {
   const api = Api.get()
     .option('-b | --bool', { type: 'boolean' })
     .option('-s | --str', { type: 'string' })
-  return api.parse('').then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.b, false)
-    t.equal(result.argv.bool, false)
-    t.equal(result.argv.s, undefined)
-    t.equal(result.argv.str, undefined)
-    t.same(result.argv._, [])
-    return api.parse('--bool false -s')
-  }).then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.b, false)
-    t.equal(result.argv.bool, false)
-    t.equal(result.argv.s, '')
-    t.equal(result.argv.str, '')
-    t.same(result.argv._, [])
-    return api.parse(['hi', '--str', 'there', '-b=true'])
-  }).then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.b, true)
-    t.equal(result.argv.bool, true)
-    t.equal(result.argv.s, 'there')
-    t.equal(result.argv.str, 'there')
-    t.same(result.argv._, ['hi'])
-  })
+
+  let result = await api.parse('')
+  assertNoErrors(t, result)
+  t.equal(result.argv.b, false)
+  t.equal(result.argv.bool, false)
+  t.equal(result.argv.s, undefined)
+  t.equal(result.argv.str, undefined)
+  t.same(result.argv._, [])
+
+  result = await api.parse('--bool false -s')
+  assertNoErrors(t, result)
+  t.equal(result.argv.b, false)
+  t.equal(result.argv.bool, false)
+  t.equal(result.argv.s, '')
+  t.equal(result.argv.str, '')
+  t.same(result.argv._, [])
+
+  result = await api.parse(['hi', '--str', 'there', '-b=true'])
+  assertNoErrors(t, result)
+  t.equal(result.argv.b, true)
+  t.equal(result.argv.bool, true)
+  t.equal(result.argv.s, 'there')
+  t.equal(result.argv.str, 'there')
+  t.same(result.argv._, ['hi'])
 })
 
-tap.test('parse > multiple concurrent passes', t => {
+tap.test('parse > multiple concurrent passes', async t => {
   const api = Api.get()
     .boolean('--bool | -b')
     .string('--str  | -s <value>')
-  const promises = []
-  promises.push(api.parse('-b -s one').then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.b, true)
-    t.equal(result.argv.bool, true)
-    t.equal(result.argv.s, 'one')
-    t.equal(result.argv.str, 'one')
-    t.same(result.argv._, [])
-  }))
-  promises.push(api.parse('--str two second').then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.b, false)
-    t.equal(result.argv.bool, false)
-    t.equal(result.argv.s, 'two')
-    t.equal(result.argv.str, 'two')
-    t.same(result.argv._, ['second'])
-  }))
-  promises.push(api.parse('third --bool').then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.b, true)
-    t.equal(result.argv.bool, true)
-    t.equal(result.argv.s, undefined)
-    t.equal(result.argv.str, undefined)
-    t.same(result.argv._, ['third'])
-  }))
-  return Promise.all(promises)
+
+  const [result1, result2, result3] = await Promise.all([
+    api.parse('-b -s one'),
+    api.parse('--str two second'),
+    api.parse('third --bool')
+  ])
+
+  assertNoErrors(t, result1)
+  t.equal(result1.argv.b, true)
+  t.equal(result1.argv.bool, true)
+  t.equal(result1.argv.s, 'one')
+  t.equal(result1.argv.str, 'one')
+  t.same(result1.argv._, [])
+
+  assertNoErrors(t, result2)
+  t.equal(result2.argv.b, false)
+  t.equal(result2.argv.bool, false)
+  t.equal(result2.argv.s, 'two')
+  t.equal(result2.argv.str, 'two')
+  t.same(result2.argv._, ['second'])
+
+  assertNoErrors(t, result3)
+  t.equal(result3.argv.b, true)
+  t.equal(result3.argv.bool, true)
+  t.equal(result3.argv.s, undefined)
+  t.equal(result3.argv.str, undefined)
+  t.same(result3.argv._, ['third'])
 })
 
-tap.test('parse > strict types', t => {
-  return Api.get()
+tap.test('parse > strict types', async t => {
+  const result = await Api.get()
     // enums are strict by default, their default value is assumed valid
     .custom(
       TypeEnum.get().flags('-e').choice(['one', 'two']).choice('three').defaultValue('none')
@@ -196,73 +195,72 @@ tap.test('parse > strict types', t => {
     .custom(TypeNumber.get().alias(['n', 'num']).strict(true).required(true))
     // strings don't have a strict mode
     .string('-s', { strict: true })
-    .parse('-n x -s').then(result => {
-      t.equal(result.code, 1)
-      t.match(result.output, /Value "NaN" is invalid for argument n or num\. Please specify a number\./)
-      t.equal(result.errors.length, 0)
-      t.equal(result.argv.e, 'none')
-      t.equal(result.argv.s, '')
-    })
+    .parse('-n x -s')
+
+  t.equal(result.code, 1)
+  t.match(result.output, /Value "NaN" is invalid for argument n or num\. Please specify a number\./)
+  t.equal(result.errors.length, 0)
+  t.equal(result.argv.e, 'none')
+  t.equal(result.argv.s, '')
 })
 
-tap.test('parse > a required string should not allow empty value', t => {
+tap.test('parse > a required string should not allow empty value', async t => {
   const api = Api.get().string('-s <string>', { required: true })
-  return api.parse('-s').then(result => {
-    t.equal(result.code, 1)
-    t.match(result.output, /Missing required argument: s/)
-    t.equal(result.errors.length, 0)
-    return api.parse('-s val')
-  }).then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.s, 'val')
-  })
+  let result = await api.parse('-s')
+  t.equal(result.code, 1)
+  t.match(result.output, /Missing required argument: s/)
+  t.equal(result.errors.length, 0)
+
+  result = await api.parse('-s val')
+  assertNoErrors(t, result)
+  t.equal(result.argv.s, 'val')
 })
 
-tap.test('parse > strict mode prevents unknown options and arguments', t => {
+tap.test('parse > strict mode prevents unknown options and arguments', async t => {
   const api = Api.get()
     .positional('[foo] [bar]')
     .string('-n, --name <string>')
     .number('-a, --age <number>')
     .strict()
-  return api.parse('--name Fred --aeg 24').then(result => {
-    // Unknown flags are detected
-    t.equal(result.code, 1)
-    t.match(result.output, /Unknown options: --aeg/)
-    t.equal(result.errors.length, 0)
-    return api.parse('send 111 222 333')
-  }).then(result => {
-    t.equal(result.code, 1)
-    t.match(result.output, /Unknown arguments: 222 333/)
-    t.equal(result.errors.length, 0)
-  })
+
+  let result = await api.parse('--name Fred --aeg 24')
+  // Unknown flags are detected
+  t.equal(result.code, 1)
+  t.match(result.output, /Unknown options: --aeg/)
+  t.equal(result.errors.length, 0)
+
+  result = await api.parse('send 111 222 333')
+  t.equal(result.code, 1)
+  t.match(result.output, /Unknown arguments: 222 333/)
+  t.equal(result.errors.length, 0)
 })
 
-tap.test('parse > strict mode prevents unknown options and arguments in command blocks', t => {
+tap.test('parse > strict mode prevents unknown options and arguments in command blocks', async t => {
   const api = Api.get()
     .string('-n, --name <string>')
     .number('-a, --age <number>')
     .command('send <studentid>')
     .strict()
-  return api.parse('send 111 --name Fred --aeg 24 --hello').then(result => {
-    // Unknown flags are detected
-    t.equal(result.code, 1)
-    t.match(result.output, /Unknown options: --aeg, --hello/)
-    t.equal(result.errors.length, 0)
-    return api.parse('send 111 222 333 --hello')
-  }).then(result => {
-    t.equal(result.code, 2)
-    t.match(result.output, /Unknown arguments: 222 333/)
-    t.match(result.output, /Unknown options: --hello/)
-    t.equal(result.errors.length, 0)
-    return api.parse('random')
-  }).then(result => {
-    t.equal(result.code, 1)
-    t.match(result.output, /Unknown arguments: random/)
-    t.equal(result.errors.length, 0)
-  })
+
+  let result = await api.parse('send 111 --name Fred --aeg 24 --hello')
+  // Unknown flags are detected
+  t.equal(result.code, 1)
+  t.match(result.output, /Unknown options: --aeg, --hello/)
+  t.equal(result.errors.length, 0)
+
+  result = await api.parse('send 111 222 333 --hello')
+  t.equal(result.code, 2)
+  t.match(result.output, /Unknown arguments: 222 333/)
+  t.match(result.output, /Unknown options: --hello/)
+  t.equal(result.errors.length, 0)
+
+  result = await api.parse('random')
+  t.equal(result.code, 1)
+  t.match(result.output, /Unknown arguments: random/)
+  t.equal(result.errors.length, 0)
 })
 
-tap.test('parse > strict mode still allows showHelpByDefault to work', t => {
+tap.test('parse > strict mode still allows showHelpByDefault to work', async t => {
   let ranCommand = false
   const api = Api.get({ name: 'program' })
     .string('-n, --name <string>')
@@ -273,46 +271,46 @@ tap.test('parse > strict mode still allows showHelpByDefault to work', t => {
     .strict()
     .showHelpByDefault()
     .outputSettings({ maxWidth: 41 })
-  return api.parse('').then(result => {
-    t.equal(result.code, 0)
-    t.equal(result.errors.length, 0)
-    t.equal(result.output, [
-      'Usage: program <command> <args> [options]',
-      '',
-      'Commands:',
-      '  send <studentid>',
-      '',
-      'Options:',
-      '  -n, --name <string>            [string]',
-      '  -a, --age <number>             [number]'
-    ].join('\n'))
-    t.equal(ranCommand, false)
-    return api.parse('send 111 222 --nmae Fred --age 24')
-  }).then(result => {
-    t.equal(result.code, 2)
-    t.equal(result.errors.length, 0)
-    t.equal(result.output, [
-      'Usage: program send <studentid> [options]',
-      '',
-      'Arguments:',
-      '  <studentid>         [required] [string]',
-      '',
-      'Options:',
-      '  -n, --name <string>            [string]',
-      '  -a, --age <number>             [number]',
-      '',
-      'Unknown options: --nmae',
-      'Unknown arguments: 222'
-    ].join('\n'))
-    t.equal(ranCommand, false)
-    return api.parse('send 111 --name Fred --age 24')
-  }).then(result => {
-    t.equal(result.code, 0)
-    t.equal(ranCommand, true)
-  })
+
+  let result = await api.parse('')
+  t.equal(result.code, 0)
+  t.equal(result.errors.length, 0)
+  t.equal(result.output, [
+    'Usage: program <command> <args> [options]',
+    '',
+    'Commands:',
+    '  send <studentid>',
+    '',
+    'Options:',
+    '  -n, --name <string>            [string]',
+    '  -a, --age <number>             [number]'
+  ].join('\n'))
+  t.equal(ranCommand, false)
+
+  result = await api.parse('send 111 222 --nmae Fred --age 24')
+  t.equal(result.code, 2)
+  t.equal(result.errors.length, 0)
+  t.equal(result.output, [
+    'Usage: program send <studentid> [options]',
+    '',
+    'Arguments:',
+    '  <studentid>         [required] [string]',
+    '',
+    'Options:',
+    '  -n, --name <string>            [string]',
+    '  -a, --age <number>             [number]',
+    '',
+    'Unknown options: --nmae',
+    'Unknown arguments: 222'
+  ].join('\n'))
+  t.equal(ranCommand, false)
+
+  result = await api.parse('send 111 --name Fred --age 24')
+  t.equal(result.code, 0)
+  t.equal(ranCommand, true)
 })
 
-tap.test('parse > strict mode ignores options/arguments after --', t => {
+tap.test('parse > strict mode ignores options/arguments after --', async t => {
   let commandArguments
   const api = Api.get()
     .string('-n, --name <string>')
@@ -321,24 +319,22 @@ tap.test('parse > strict mode ignores options/arguments after --', t => {
       commandArguments = argv._
     })
     .strict()
-  return api.parse('send 111 -n Fred --aeg 24 222 -- 333 --force').then(result => {
-    t.equal(result.code, 2)
-    t.match(result.output, /Unknown options: --aeg/)
-    t.match(result.output, /Unknown arguments: 222/)
-    t.equal(result.errors.length, 0)
-    t.equal(commandArguments, undefined)
-    return api.parse('send 111 -n Fred --age 24 -- 222 333 --force')
-  }).then(result => {
-    t.equal(result.code, 0)
-    t.equal(result.errors.length, 0)
-    t.equal(result.output, '')
-    t.strictSame(commandArguments, ['--', '222', '333', '--force'])
-  })
+
+  let result = await api.parse('send 111 -n Fred --aeg 24 222 -- 333 --force')
+  t.equal(result.code, 2)
+  t.match(result.output, /Unknown options: --aeg/)
+  t.match(result.output, /Unknown arguments: 222/)
+  t.equal(result.errors.length, 0)
+  t.equal(commandArguments, undefined)
+
+  result = await api.parse('send 111 -n Fred --age 24 -- 222 333 --force')
+  t.equal(result.code, 0)
+  t.equal(result.errors.length, 0)
+  t.equal(result.output, '')
+  t.strictSame(commandArguments, ['--', '222', '333', '--force'])
 })
 
-tap.test('parse > coerced types', t => {
-  const promises = []
-
+tap.test('parse > coerced types', async t => {
   const api = Api.get()
     .boolean('-b', { coerce: val => val ? 'yay' : 'boo' })
     .string('-s', { coerce: val => val && val.split('..') })
@@ -350,23 +346,22 @@ tap.test('parse > coerced types', t => {
       }
     })
 
-  promises.push(api.parse('-b -s 1..2 -n 5').then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.b, 'yay')
-    t.same(result.argv.s, ['1', '2'])
-    t.equal(result.argv.n, 5000)
-  }))
+  const [result1, result2] = await Promise.all([
+    api.parse('-b -s 1..2 -n 5'),
+    api.parse('-x')
+  ])
 
-  promises.push(api.parse('-x').then(result => {
-    t.equal(result.code, 1)
-    t.match(result.output, /Blow up/)
-    t.equal(result.errors.length, 1)
-  }))
+  assertNoErrors(t, result1)
+  t.equal(result1.argv.b, 'yay')
+  t.same(result1.argv.s, ['1', '2'])
+  t.equal(result1.argv.n, 5000)
 
-  return Promise.all(promises)
+  t.equal(result2.code, 1)
+  t.match(result2.output, /Blow up/)
+  t.equal(result2.errors.length, 1)
 })
 
-tap.test('parse > custom async check', t => {
+tap.test('parse > custom async check', async t => {
   // cliMessage, reject, throw, success, not called on help
   let called = 0
 
@@ -380,41 +375,38 @@ tap.test('parse > custom async check', t => {
     } else if (argv.reject) {
       return Promise.reject(new Error('Custom check rejected'))
     }
-    return Promise.resolve().then(() => {
-      argv.looksGood = true
-    })
+    argv.looksGood = true
   })
 
-  return api.parse('--help').then(result => {
-    t.equal(result.code, 0)
-    t.equal(result.errors.length, 0)
-    t.equal(called, 0)
-    t.equal(result.argv.looksGood, undefined)
-    return api.parse('--msg "Not allowed"')
-  }).then(result => {
-    t.equal(result.code, 1)
-    t.match(result.output, /Not allowed/)
-    t.equal(result.errors.length, 0)
-    t.equal(called, 1)
-    t.equal(result.argv.looksGood, false)
-    return api.parse('--throw')
-  }).then(result => {
-    t.equal(result.code, 1)
-    t.match(result.output, /Thrown by custom check/)
-    t.equal(result.errors.length, 1)
-    t.equal(called, 2)
-    t.equal(result.argv.looksGood, false)
-    return api.parse('--reject')
-  }).then(result => {
-    t.equal(result.code, 1)
-    t.match(result.output, /Custom check rejected/)
-    t.equal(result.errors.length, 1)
-    t.equal(called, 3)
-    t.equal(result.argv.looksGood, false)
-    return api.parse('')
-  }).then(result => {
-    assertNoErrors(t, result)
-    t.equal(called, 4)
-    t.equal(result.argv.looksGood, true)
-  })
+  let result = await api.parse('--help')
+  t.equal(result.code, 0)
+  t.equal(result.errors.length, 0)
+  t.equal(called, 0)
+  t.equal(result.argv.looksGood, undefined)
+
+  result = await api.parse('--msg "Not allowed"')
+  t.equal(result.code, 1)
+  t.match(result.output, /Not allowed/)
+  t.equal(result.errors.length, 0)
+  t.equal(called, 1)
+  t.equal(result.argv.looksGood, false)
+
+  result = await api.parse('--throw')
+  t.equal(result.code, 1)
+  t.match(result.output, /Thrown by custom check/)
+  t.equal(result.errors.length, 1)
+  t.equal(called, 2)
+  t.equal(result.argv.looksGood, false)
+
+  result = await api.parse('--reject')
+  t.equal(result.code, 1)
+  t.match(result.output, /Custom check rejected/)
+  t.equal(result.errors.length, 1)
+  t.equal(called, 3)
+  t.equal(result.argv.looksGood, false)
+
+  result = await api.parse('')
+  assertNoErrors(t, result)
+  t.equal(called, 4)
+  t.equal(result.argv.looksGood, true)
 })

--- a/test/types/test-array.js
+++ b/test/types/test-array.js
@@ -9,39 +9,38 @@ const helper = require('../helper').get(parent)
 const assertNoErrors = helper.assertNoErrors.bind(helper)
 const assertTypeDetails = helper.assertTypeDetails.bind(helper)
 
-tap.test('array > via specific api methods', t => {
-  return Api.get()
+tap.test('array > via specific api methods', async t => {
+  const result = await Api.get()
     .array('-a, --array <vals..>')
     .stringArray('-s, --strings <one or more strings>')
     .numberArray('-n, --numbers <n1 [n2 n3..]>')
     .parse('before -a one two -s one,two -s three four -n=1 2 3,4 -- after')
-    .then(result => {
-      assertNoErrors(t, result)
 
-      t.same(result.argv.a, ['one', 'two'])
-      t.same(result.argv.array, ['one', 'two'])
-      t.same(result.argv.s, ['one', 'two', 'three', 'four'])
-      t.same(result.argv.strings, ['one', 'two', 'three', 'four'])
-      t.same(result.argv.n, [1, 2, 3, 4])
-      t.same(result.argv.numbers, [1, 2, 3, 4])
-      t.same(result.argv._, ['before', '--', 'after'])
+  assertNoErrors(t, result)
 
-      t.same(result.details.args, [
-        'before', '-a', 'one', 'two', '-s', 'one,two', '-s', 'three', 'four',
-        '-n=1', '2', '3,4', '--', 'after'
-      ])
+  t.same(result.argv.a, ['one', 'two'])
+  t.same(result.argv.array, ['one', 'two'])
+  t.same(result.argv.s, ['one', 'two', 'three', 'four'])
+  t.same(result.argv.strings, ['one', 'two', 'three', 'four'])
+  t.same(result.argv.n, [1, 2, 3, 4])
+  t.same(result.argv.numbers, [1, 2, 3, 4])
+  t.same(result.argv._, ['before', '--', 'after'])
 
-      t.equal(result.details.types.length, 4)
+  t.same(result.details.args, [
+    'before', '-a', 'one', 'two', '-s', 'one,two', '-s', 'three', 'four',
+    '-n=1', '2', '3,4', '--', 'after'
+  ])
 
-      assertTypeDetails(t, result, 0, ['_'], 'array:string', ['before', '--', 'after'], 'positional', [0, 12, 13], ['before', '--', 'after'])
-      assertTypeDetails(t, result, 1, ['a', 'array'], 'array:string', ['one', 'two'], 'flag', [1, 2, 3], ['-a', 'one', 'two'])
-      assertTypeDetails(t, result, 2, ['s', 'strings'], 'array:string', ['one', 'two', 'three', 'four'], 'flag', [4, 5, 6, 7, 8], ['-s', 'one,two', '-s', 'three', 'four'])
-      assertTypeDetails(t, result, 3, ['n', 'numbers'], 'array:number', [1, 2, 3, 4], 'flag', [9, 10, 11], ['-n=1', '2', '3,4'])
-    })
+  t.equal(result.details.types.length, 4)
+
+  assertTypeDetails(t, result, 0, ['_'], 'array:string', ['before', '--', 'after'], 'positional', [0, 12, 13], ['before', '--', 'after'])
+  assertTypeDetails(t, result, 1, ['a', 'array'], 'array:string', ['one', 'two'], 'flag', [1, 2, 3], ['-a', 'one', 'two'])
+  assertTypeDetails(t, result, 2, ['s', 'strings'], 'array:string', ['one', 'two', 'three', 'four'], 'flag', [4, 5, 6, 7, 8], ['-s', 'one,two', '-s', 'three', 'four'])
+  assertTypeDetails(t, result, 3, ['n', 'numbers'], 'array:number', [1, 2, 3, 4], 'flag', [9, 10, 11], ['-n=1', '2', '3,4'])
 })
 
-tap.test('array > via generic api method', t => {
-  return Api.get()
+tap.test('array > via generic api method', async t => {
+  const result = await Api.get()
     .option('--array', { type: 'array' })
     .option('--strings', { type: 'array:string' })
     .option('--numbers', { type: 'array:number' })
@@ -50,76 +49,71 @@ tap.test('array > via generic api method', t => {
     .option('--files', { type: 'array:file' })
     .option('--dirs', { type: 'array:dir' })
     .parse('--array a,b --strings c d --dirs i --numbers one 2 --enums good bad --paths e f --files=g,h --dirs j')
-    .then(result => {
-      assertNoErrors(t, result)
 
-      t.same(result.argv._, [])
-      t.same(result.argv.array, ['a', 'b'])
-      t.same(result.argv.strings, ['c', 'd'])
-      t.same(result.argv.numbers, [NaN, 2])
-      t.same(result.argv.enums, ['good', 'bad'])
-      t.same(result.argv.paths, ['e', 'f'])
-      t.same(result.argv.files, ['g', 'h'])
-      t.same(result.argv.dirs, ['i', 'j'])
+  assertNoErrors(t, result)
 
-      t.same(result.details.args, [
-        '--array', 'a,b', '--strings', 'c', 'd', '--dirs', 'i', '--numbers', 'one',
-        '2', '--enums', 'good', 'bad', '--paths', 'e', 'f', '--files=g,h', '--dirs', 'j'
-      ])
+  t.same(result.argv._, [])
+  t.same(result.argv.array, ['a', 'b'])
+  t.same(result.argv.strings, ['c', 'd'])
+  t.same(result.argv.numbers, [NaN, 2])
+  t.same(result.argv.enums, ['good', 'bad'])
+  t.same(result.argv.paths, ['e', 'f'])
+  t.same(result.argv.files, ['g', 'h'])
+  t.same(result.argv.dirs, ['i', 'j'])
 
-      t.equal(result.details.types.length, 8)
+  t.same(result.details.args, [
+    '--array', 'a,b', '--strings', 'c', 'd', '--dirs', 'i', '--numbers', 'one',
+    '2', '--enums', 'good', 'bad', '--paths', 'e', 'f', '--files=g,h', '--dirs', 'j'
+  ])
 
-      assertTypeDetails(t, result, 0, ['_'], 'array:string', [], 'default', [], [])
-      assertTypeDetails(t, result, 1, ['array'], 'array:string', ['a', 'b'], 'flag', [0, 1], ['--array', 'a,b'])
-      assertTypeDetails(t, result, 2, ['strings'], 'array:string', ['c', 'd'], 'flag', [2, 3, 4], ['--strings', 'c', 'd'])
-      assertTypeDetails(t, result, 3, ['numbers'], 'array:number', [NaN, 2], 'flag', [7, 8, 9], ['--numbers', 'one', '2'])
-      assertTypeDetails(t, result, 4, ['enums'], 'array:enum', ['good', 'bad'], 'flag', [10, 11, 12], ['--enums', 'good', 'bad'])
-      assertTypeDetails(t, result, 5, ['paths'], 'array:path', ['e', 'f'], 'flag', [13, 14, 15], ['--paths', 'e', 'f'])
-      assertTypeDetails(t, result, 6, ['files'], 'array:file', ['g', 'h'], 'flag', [16], ['--files=g,h'])
-      assertTypeDetails(t, result, 7, ['dirs'], 'array:dir', ['i', 'j'], 'flag', [5, 6, 17, 18], ['--dirs', 'i', '--dirs', 'j'])
-    })
+  t.equal(result.details.types.length, 8)
+
+  assertTypeDetails(t, result, 0, ['_'], 'array:string', [], 'default', [], [])
+  assertTypeDetails(t, result, 1, ['array'], 'array:string', ['a', 'b'], 'flag', [0, 1], ['--array', 'a,b'])
+  assertTypeDetails(t, result, 2, ['strings'], 'array:string', ['c', 'd'], 'flag', [2, 3, 4], ['--strings', 'c', 'd'])
+  assertTypeDetails(t, result, 3, ['numbers'], 'array:number', [NaN, 2], 'flag', [7, 8, 9], ['--numbers', 'one', '2'])
+  assertTypeDetails(t, result, 4, ['enums'], 'array:enum', ['good', 'bad'], 'flag', [10, 11, 12], ['--enums', 'good', 'bad'])
+  assertTypeDetails(t, result, 5, ['paths'], 'array:path', ['e', 'f'], 'flag', [13, 14, 15], ['--paths', 'e', 'f'])
+  assertTypeDetails(t, result, 6, ['files'], 'array:file', ['g', 'h'], 'flag', [16], ['--files=g,h'])
+  assertTypeDetails(t, result, 7, ['dirs'], 'array:dir', ['i', 'j'], 'flag', [5, 6, 17, 18], ['--dirs', 'i', '--dirs', 'j'])
 })
 
-tap.test('array > default value', t => {
+tap.test('array > default value', async t => {
   const api = Api.get()
     .array('--defaultDefault')
     .array('--customDefaultArray', { defaultValue: ['hi', 'there'] })
     .array('--customDefaultValue', { defaultValue: 'string' })
-  return api.parse('').then(result => {
-    assertNoErrors(t, result)
-    t.same(result.argv.defaultDefault, [])
-    t.same(result.argv.customDefaultArray, ['hi', 'there'])
-    t.same(result.argv.customDefaultValue, ['string'])
-    return api.parse('--customDefaultArray joe bob --customDefaultValue yo')
-  }).then(result => {
-    assertNoErrors(t, result)
-    t.same(result.argv.defaultDefault, [])
-    t.same(result.argv.customDefaultArray, ['joe', 'bob'])
-    t.same(result.argv.customDefaultValue, ['yo'])
-  })
+
+  let result = await api.parse('')
+  assertNoErrors(t, result)
+  t.same(result.argv.defaultDefault, [])
+  t.same(result.argv.customDefaultArray, ['hi', 'there'])
+  t.same(result.argv.customDefaultValue, ['string'])
+
+  result = await api.parse('--customDefaultArray joe bob --customDefaultValue yo')
+  assertNoErrors(t, result)
+  t.same(result.argv.defaultDefault, [])
+  t.same(result.argv.customDefaultArray, ['joe', 'bob'])
+  t.same(result.argv.customDefaultValue, ['yo'])
 })
 
-tap.test('array > custom delimiter', t => {
-  return Api.get()
+tap.test('array > custom delimiter', async t => {
+  const result = await Api.get()
     .array('--dash <one-two-n..>', { delimiter: '-' })
     .parse('--dash a-b-c d,e f')
-    .then(result => {
-      assertNoErrors(t, result)
-      t.same(result.argv.dash, ['a', 'b', 'c', 'd,e', 'f'])
-    })
+  assertNoErrors(t, result)
+  t.same(result.argv.dash, ['a', 'b', 'c', 'd,e', 'f'])
 })
 
-tap.test('array > not cumulative', t => {
-  return Api.get()
+tap.test('array > not cumulative', async t => {
+  const result = await Api.get()
     .array('--lastFlagWins', { cumulative: false })
     .parse('--lastFlagWins a b --lastFlagWins c d --lastFlagWins e f')
-    .then(result => {
-      assertNoErrors(t, result)
-      t.same(result.argv.lastFlagWins, ['e', 'f'])
-    })
+  assertNoErrors(t, result)
+  t.same(result.argv.lastFlagWins, ['e', 'f'])
 })
 
-tap.test('array > nested', t => {
+tap.test('array > nested', async t => {
   const api = Api.get().custom(
     TypeArray.get()
       .of(TypeArray.get().cumulative(false))
@@ -127,41 +121,40 @@ tap.test('array > nested', t => {
       .desc('Interesting CLI choice here')
       .delimiter(false)
   )
-  return api.parse('-N a b -N c,d -N=e f').then(result => {
-    assertNoErrors(t, result)
+  const result = await api.parse('-N a b -N c,d -N=e f')
+  assertNoErrors(t, result)
 
-    const nested = result.argv.nested
-    t.equal(nested.length, 3)
-    t.same(nested[0], ['a', 'b'])
-    t.same(nested[1], ['c', 'd'])
-    t.same(nested[2], ['e', 'f'])
+  const nested = result.argv.nested
+  t.equal(nested.length, 3)
+  t.same(nested[0], ['a', 'b'])
+  t.same(nested[1], ['c', 'd'])
+  t.same(nested[2], ['e', 'f'])
 
-    t.equal(result.details.types.length, 2)
+  t.equal(result.details.types.length, 2)
 
-    assertTypeDetails(t, result, 1, ['N', 'nested'], 'array:array:string', '_SKIP_', 'flag', [0, 1, 2, 3, 4, 5, 6], ['-N', 'a', 'b', '-N', 'c,d', '-N=e', 'f'])
-  })
+  assertTypeDetails(t, result, 1, ['N', 'nested'], 'array:array:string', '_SKIP_', 'flag', [0, 1, 2, 3, 4, 5, 6], ['-N', 'a', 'b', '-N', 'c,d', '-N=e', 'f'])
 })
 
-tap.test('array > required', t => {
+tap.test('array > required', async t => {
   const api = Api.get().array('-a|--array', { required: true })
-  return api.parse('').then(result => {
-    t.equal(result.code, 1)
-    t.match(result.output, /Missing required argument: a or array/)
-    t.equal(result.errors.length, 0)
-    return api.parse('-a')
-  }).then(result => {
-    assertNoErrors(t, result)
-    t.same(result.argv.a, [''])
-    t.same(result.argv.array, [''])
-    return api.parse('-a hi')
-  }).then(result => {
-    assertNoErrors(t, result)
-    t.same(result.argv.a, ['hi'])
-    t.same(result.argv.array, ['hi'])
-  })
+
+  let result = await api.parse('')
+  t.equal(result.code, 1)
+  t.match(result.output, /Missing required argument: a or array/)
+  t.equal(result.errors.length, 0)
+
+  result = await api.parse('-a')
+  assertNoErrors(t, result)
+  t.same(result.argv.a, [''])
+  t.same(result.argv.array, [''])
+
+  result = await api.parse('-a hi')
+  assertNoErrors(t, result)
+  t.same(result.argv.a, ['hi'])
+  t.same(result.argv.array, ['hi'])
 })
 
-tap.test('array > strict', t => {
+tap.test('array > strict', async t => {
   // types with a strict mode: enum, number, path
   const api = Api.get()
     .numberArray('n', {
@@ -175,17 +168,17 @@ tap.test('array > strict', t => {
       type: 'array:path',
       mustExist: true // paths are only strict if mustExist is a boolean
     })
-  return api.parse('-n no -e ruby -p blerg_dne').then(result => {
-    t.equal(result.code, 3)
-    t.match(result.output, /Value "NaN" is invalid for argument n\. Please specify a number\./)
-    t.match(result.output, /Value "ruby" is invalid for argument e\. Choices are: node, java, rust/)
-    t.match(result.output, /The path does not exist: blerg_dne/)
-    t.equal(result.errors.length, 0)
-    return api.parse(`-p ${__filename} -e node -n 0`)
-  }).then(result => {
-    assertNoErrors(t, result)
-    t.same(result.argv.n, [0])
-    t.same(result.argv.e, ['node'])
-    t.same(result.argv.p, [__filename])
-  })
+
+  let result = await api.parse('-n no -e ruby -p blerg_dne')
+  t.equal(result.code, 3)
+  t.match(result.output, /Value "NaN" is invalid for argument n\. Please specify a number\./)
+  t.match(result.output, /Value "ruby" is invalid for argument e\. Choices are: node, java, rust/)
+  t.match(result.output, /The path does not exist: blerg_dne/)
+  t.equal(result.errors.length, 0)
+
+  result = await api.parse(`-p ${__filename} -e node -n 0`)
+  assertNoErrors(t, result)
+  t.same(result.argv.n, [0])
+  t.same(result.argv.e, ['node'])
+  t.same(result.argv.p, [__filename])
 })

--- a/test/types/test-command.js
+++ b/test/types/test-command.js
@@ -11,34 +11,34 @@ const assertTypeDetails = helper.assertTypeDetails.bind(helper)
 
 tap.test('command > custom check handling at different levels')
 
-tap.test('command > dsl string and run handler', t => {
+tap.test('command > dsl string and run handler', async t => {
   let runCalled = 0
   let innerArgv
   const api = Api.get().command('do <it>', argv => {
     runCalled++
     innerArgv = argv
   })
-  return api.parse('do').then(result => {
-    t.equal(runCalled, 0) // does not execute handler on validation failure
-    t.equal(innerArgv, undefined)
-    t.equal(result.code, 1)
-    t.match(result.output, /Missing required argument: it/)
-    t.equal(result.errors.length, 0)
-    return api.parse('do something')
-  }).then(result => {
-    assertNoErrors(t, result)
-    t.equal(runCalled, 1)
-    t.equal(innerArgv.it, 'something')
-    t.same(innerArgv._, [])
-    t.equal(result.argv.it, 'something')
-    t.same(result.argv._, [])
-    assertTypeDetails(t, result, 0, ['_'], 'array:string', [], 'default', [], [])
-    assertTypeDetails(t, result, 1, ['do'], 'command', true, 'positional', [0], ['do'])
-    Helper.get(`${parent} do`).assertTypeDetails(t, result, 2, ['it'], 'string', 'something', 'positional', [1], ['something'])
-  })
+
+  let result = await api.parse('do')
+  t.equal(runCalled, 0) // does not execute handler on validation failure
+  t.equal(innerArgv, undefined)
+  t.equal(result.code, 1)
+  t.match(result.output, /Missing required argument: it/)
+  t.equal(result.errors.length, 0)
+
+  result = await api.parse('do something')
+  assertNoErrors(t, result)
+  t.equal(runCalled, 1)
+  t.equal(innerArgv.it, 'something')
+  t.same(innerArgv._, [])
+  t.equal(result.argv.it, 'something')
+  t.same(result.argv._, [])
+  assertTypeDetails(t, result, 0, ['_'], 'array:string', [], 'default', [], [])
+  assertTypeDetails(t, result, 1, ['do'], 'command', true, 'positional', [0], ['do'])
+  Helper.get(`${parent} do`).assertTypeDetails(t, result, 2, ['it'], 'string', 'something', 'positional', [1], ['something'])
 })
 
-tap.test('command > dsl string and opts object', t => {
+tap.test('command > dsl string and opts object', async t => {
   let setupCalled = 0
   let runCalled = 0
   let innerArgv
@@ -54,32 +54,32 @@ tap.test('command > dsl string and opts object', t => {
   t.equal(Object.keys(opts).length, 2)
   t.equal(typeof opts.setup, 'function')
   t.equal(typeof opts.run, 'function')
-  return api.parse('do').then(result => {
-    t.equal(setupCalled, 1)
-    t.equal(runCalled, 0)
-    t.equal(innerArgv, undefined)
-    t.equal(result.code, 1)
-    t.match(result.output, /Missing required argument: it/)
-    t.equal(result.errors.length, 0)
-    return api.parse('do something')
-  }).then(result => {
-    assertNoErrors(t, result)
-    // each command setup should only be called once for a single api instance
-    // since it is meant to add types, thus modifying the api's state
-    // CONFIGURE ONCE, RUN INFINITY!
-    t.equal(setupCalled, 1)
-    t.equal(runCalled, 1)
-    t.equal(innerArgv.it, 'something')
-    t.same(innerArgv._, [])
-    t.equal(result.argv.it, 'something')
-    t.same(result.argv._, [])
-    assertTypeDetails(t, result, 0, ['_'], 'array:string', [], 'default', [], [])
-    assertTypeDetails(t, result, 1, ['do'], 'command', true, 'positional', [0], ['do'])
-    Helper.get(`${parent} do`).assertTypeDetails(t, result, 2, ['it'], 'string', 'something', 'positional', [1], ['something'])
-  })
+
+  let result = await api.parse('do')
+  t.equal(setupCalled, 1)
+  t.equal(runCalled, 0)
+  t.equal(innerArgv, undefined)
+  t.equal(result.code, 1)
+  t.match(result.output, /Missing required argument: it/)
+  t.equal(result.errors.length, 0)
+
+  result = await api.parse('do something')
+  assertNoErrors(t, result)
+  // each command setup should only be called once for a single api instance
+  // since it is meant to add types, thus modifying the api's state
+  // CONFIGURE ONCE, RUN INFINITY!
+  t.equal(setupCalled, 1)
+  t.equal(runCalled, 1)
+  t.equal(innerArgv.it, 'something')
+  t.same(innerArgv._, [])
+  t.equal(result.argv.it, 'something')
+  t.same(result.argv._, [])
+  assertTypeDetails(t, result, 0, ['_'], 'array:string', [], 'default', [], [])
+  assertTypeDetails(t, result, 1, ['do'], 'command', true, 'positional', [0], ['do'])
+  Helper.get(`${parent} do`).assertTypeDetails(t, result, 2, ['it'], 'string', 'something', 'positional', [1], ['something'])
 })
 
-tap.test('command > opts object (aka command module) with flags', t => {
+tap.test('command > opts object (aka command module) with flags', async t => {
   let setupCalled = 0
   let runCalled = 0
   let innerArgv
@@ -97,29 +97,29 @@ tap.test('command > opts object (aka command module) with flags', t => {
   t.equal(module.flags, 'do <it>')
   t.equal(typeof module.setup, 'function')
   t.equal(typeof module.run, 'function')
-  return api.parse('do').then(result => {
-    t.equal(setupCalled, 1)
-    t.equal(runCalled, 0)
-    t.equal(innerArgv, undefined)
-    t.equal(result.code, 1)
-    t.match(result.output, /Missing required argument: it/)
-    t.equal(result.errors.length, 0)
-    return api.parse('do something')
-  }).then(result => {
-    assertNoErrors(t, result)
-    t.equal(setupCalled, 1)
-    t.equal(runCalled, 1)
-    t.equal(innerArgv.it, 'something')
-    t.same(innerArgv._, [])
-    t.equal(result.argv.it, 'something')
-    t.same(result.argv._, [])
-    assertTypeDetails(t, result, 0, ['_'], 'array:string', [], 'default', [], [])
-    assertTypeDetails(t, result, 1, ['do'], 'command', true, 'positional', [0], ['do'])
-    Helper.get(`${parent} do`).assertTypeDetails(t, result, 2, ['it'], 'string', 'something', 'positional', [1], ['something'])
-  })
+
+  let result = await api.parse('do')
+  t.equal(setupCalled, 1)
+  t.equal(runCalled, 0)
+  t.equal(innerArgv, undefined)
+  t.equal(result.code, 1)
+  t.match(result.output, /Missing required argument: it/)
+  t.equal(result.errors.length, 0)
+
+  result = await api.parse('do something')
+  assertNoErrors(t, result)
+  t.equal(setupCalled, 1)
+  t.equal(runCalled, 1)
+  t.equal(innerArgv.it, 'something')
+  t.same(innerArgv._, [])
+  t.equal(result.argv.it, 'something')
+  t.same(result.argv._, [])
+  assertTypeDetails(t, result, 0, ['_'], 'array:string', [], 'default', [], [])
+  assertTypeDetails(t, result, 1, ['do'], 'command', true, 'positional', [0], ['do'])
+  Helper.get(`${parent} do`).assertTypeDetails(t, result, 2, ['it'], 'string', 'something', 'positional', [1], ['something'])
 })
 
-tap.test('command > opts object (aka command module) with flags as 2nd argument', t => {
+tap.test('command > opts object (aka command module) with flags as 2nd argument', async t => {
   let setupCalled = 0
   let runCalled = 0
   let innerArgv
@@ -137,29 +137,29 @@ tap.test('command > opts object (aka command module) with flags as 2nd argument'
   t.equal(module.flags, 'do <it>')
   t.equal(typeof module.setup, 'function')
   t.equal(typeof module.run, 'function')
-  return api.parse('do').then(result => {
-    t.equal(setupCalled, 1)
-    t.equal(runCalled, 0)
-    t.equal(innerArgv, undefined)
-    t.equal(result.code, 1)
-    t.match(result.output, /Missing required argument: it/)
-    t.equal(result.errors.length, 0)
-    return api.parse('do something')
-  }).then(result => {
-    assertNoErrors(t, result)
-    t.equal(setupCalled, 1)
-    t.equal(runCalled, 1)
-    t.equal(innerArgv.it, 'something')
-    t.same(innerArgv._, [])
-    t.equal(result.argv.it, 'something')
-    t.same(result.argv._, [])
-    assertTypeDetails(t, result, 0, ['_'], 'array:string', [], 'default', [], [])
-    assertTypeDetails(t, result, 1, ['do'], 'command', true, 'positional', [0], ['do'])
-    Helper.get(`${parent} do`).assertTypeDetails(t, result, 2, ['it'], 'string', 'something', 'positional', [1], ['something'])
-  })
+
+  let result = await api.parse('do')
+  t.equal(setupCalled, 1)
+  t.equal(runCalled, 0)
+  t.equal(innerArgv, undefined)
+  t.equal(result.code, 1)
+  t.match(result.output, /Missing required argument: it/)
+  t.equal(result.errors.length, 0)
+
+  result = await api.parse('do something')
+  assertNoErrors(t, result)
+  t.equal(setupCalled, 1)
+  t.equal(runCalled, 1)
+  t.equal(innerArgv.it, 'something')
+  t.same(innerArgv._, [])
+  t.equal(result.argv.it, 'something')
+  t.same(result.argv._, [])
+  assertTypeDetails(t, result, 0, ['_'], 'array:string', [], 'default', [], [])
+  assertTypeDetails(t, result, 1, ['do'], 'command', true, 'positional', [0], ['do'])
+  Helper.get(`${parent} do`).assertTypeDetails(t, result, 2, ['it'], 'string', 'something', 'positional', [1], ['something'])
 })
 
-tap.test('command > opts object (aka command module) with aliases', t => {
+tap.test('command > opts object (aka command module) with aliases', async t => {
   let setupCalled = 0
   let runCalled = 0
   let innerArgv
@@ -181,29 +181,29 @@ tap.test('command > opts object (aka command module) with aliases', t => {
   t.equal(module.params[0].flags, '<it>')
   t.equal(typeof module.setup, 'function')
   t.equal(typeof module.run, 'function')
-  return api.parse('do').then(result => {
-    t.equal(setupCalled, 1)
-    t.equal(runCalled, 0)
-    t.equal(innerArgv, undefined)
-    t.equal(result.code, 1)
-    t.match(result.output, /Missing required argument: it/)
-    t.equal(result.errors.length, 0)
-    return api.parse('do something')
-  }).then(result => {
-    assertNoErrors(t, result)
-    t.equal(setupCalled, 1)
-    t.equal(runCalled, 1)
-    t.equal(innerArgv.it, 'something')
-    t.same(innerArgv._, [])
-    t.equal(result.argv.it, 'something')
-    t.same(result.argv._, [])
-    assertTypeDetails(t, result, 0, ['_'], 'array:string', [], 'default', [], [])
-    assertTypeDetails(t, result, 1, ['do'], 'command', true, 'positional', [0], ['do'])
-    Helper.get(`${parent} do`).assertTypeDetails(t, result, 2, ['it'], 'string', 'something', 'positional', [1], ['something'])
-  })
+
+  let result = await api.parse('do')
+  t.equal(setupCalled, 1)
+  t.equal(runCalled, 0)
+  t.equal(innerArgv, undefined)
+  t.equal(result.code, 1)
+  t.match(result.output, /Missing required argument: it/)
+  t.equal(result.errors.length, 0)
+
+  result = await api.parse('do something')
+  assertNoErrors(t, result)
+  t.equal(setupCalled, 1)
+  t.equal(runCalled, 1)
+  t.equal(innerArgv.it, 'something')
+  t.same(innerArgv._, [])
+  t.equal(result.argv.it, 'something')
+  t.same(result.argv._, [])
+  assertTypeDetails(t, result, 0, ['_'], 'array:string', [], 'default', [], [])
+  assertTypeDetails(t, result, 1, ['do'], 'command', true, 'positional', [0], ['do'])
+  Helper.get(`${parent} do`).assertTypeDetails(t, result, 2, ['it'], 'string', 'something', 'positional', [1], ['something'])
 })
 
-tap.test('command > opts object (aka command module) with paramsDsl', t => {
+tap.test('command > opts object (aka command module) with paramsDsl', async t => {
   let setupCalled = 0
   let runCalled = 0
   let innerArgv
@@ -223,29 +223,29 @@ tap.test('command > opts object (aka command module) with paramsDsl', t => {
   t.equal(module.paramsDsl, '<it>')
   t.equal(typeof module.setup, 'function')
   t.equal(typeof module.run, 'function')
-  return api.parse('do').then(result => {
-    t.equal(setupCalled, 1)
-    t.equal(runCalled, 0)
-    t.equal(innerArgv, undefined)
-    t.equal(result.code, 1)
-    t.match(result.output, /Missing required argument: it/)
-    t.equal(result.errors.length, 0)
-    return api.parse('do something')
-  }).then(result => {
-    assertNoErrors(t, result)
-    t.equal(setupCalled, 1)
-    t.equal(runCalled, 1)
-    t.equal(innerArgv.it, 'something')
-    t.same(innerArgv._, [])
-    t.equal(result.argv.it, 'something')
-    t.same(result.argv._, [])
-    assertTypeDetails(t, result, 0, ['_'], 'array:string', [], 'default', [], [])
-    assertTypeDetails(t, result, 1, ['do'], 'command', true, 'positional', [0], ['do'])
-    Helper.get(`${parent} do`).assertTypeDetails(t, result, 2, ['it'], 'string', 'something', 'positional', [1], ['something'])
-  })
+
+  let result = await api.parse('do')
+  t.equal(setupCalled, 1)
+  t.equal(runCalled, 0)
+  t.equal(innerArgv, undefined)
+  t.equal(result.code, 1)
+  t.match(result.output, /Missing required argument: it/)
+  t.equal(result.errors.length, 0)
+
+  result = await api.parse('do something')
+  assertNoErrors(t, result)
+  t.equal(setupCalled, 1)
+  t.equal(runCalled, 1)
+  t.equal(innerArgv.it, 'something')
+  t.same(innerArgv._, [])
+  t.equal(result.argv.it, 'something')
+  t.same(result.argv._, [])
+  assertTypeDetails(t, result, 0, ['_'], 'array:string', [], 'default', [], [])
+  assertTypeDetails(t, result, 1, ['do'], 'command', true, 'positional', [0], ['do'])
+  Helper.get(`${parent} do`).assertTypeDetails(t, result, 2, ['it'], 'string', 'something', 'positional', [1], ['something'])
 })
 
-tap.test('command > subcommands with dynamic usage', t => {
+tap.test('command > subcommands with dynamic usage', async t => {
   const api = Api.get()
     .configure({ name: 'nug' })
     .showHelpByDefault()
@@ -292,171 +292,159 @@ tap.test('command > subcommands with dynamic usage', t => {
     .help()
     .outputSettings({ maxWidth: 70 })
 
-  const promises = []
+  const [result1, result2, result3, result4, result5, result6, result7, result8, result9, result10, result11] = await Promise.all([
+    api.parse(''),
+    api.parse('help remote'),
+    api.parse('help remote add'),
+    api.parse('remote --help add'),
+    api.parse('remote prune --help'),
+    api.parse('--help remote list'),
+    api.parse('stash'),
+    api.parse('help stash list'),
+    api.parse('stash --help show'),
+    api.parse('stash save --help'),
+    api.parse('help stash')
+  ])
 
-  promises.push(api.parse('').then(result => {
-    t.equal(result.code, 0)
-    t.equal(result.errors.length, 0)
-    t.equal(result.output, [
-      'Usage: nug <command> <args> [options]',
-      '',
-      'Commands:',
-      '  remote <subcommand>  Work with remotes',
-      '  stash                Stash away changes in dirty working directory',
-      '',
-      'Options:',
-      '  --help  Show help                         [commands: help] [boolean]'
-    ].join('\n'))
-  }))
+  t.equal(result1.code, 0)
+  t.equal(result1.errors.length, 0)
+  t.equal(result1.output, [
+    'Usage: nug <command> <args> [options]',
+    '',
+    'Commands:',
+    '  remote <subcommand>  Work with remotes',
+    '  stash                Stash away changes in dirty working directory',
+    '',
+    'Options:',
+    '  --help  Show help                         [commands: help] [boolean]'
+  ].join('\n'))
 
-  promises.push(api.parse('help remote').then(result => {
-    t.equal(result.code, 0)
-    t.equal(result.errors.length, 0)
-    t.equal(result.output, [
-      'Usage: nug remote <subcommand> [options]',
-      '',
-      'Commands:',
-      '  add <name> <url>  Add a remote',
-      '  prune <name>      Delete stale branches from the remote',
-      '  list              Show existing remotes                    [default]',
-      '',
-      'Options:',
-      '  --help  Show help                         [commands: help] [boolean]'
-    ].join('\n'))
-  }))
+  t.equal(result2.code, 0)
+  t.equal(result2.errors.length, 0)
+  t.equal(result2.output, [
+    'Usage: nug remote <subcommand> [options]',
+    '',
+    'Commands:',
+    '  add <name> <url>  Add a remote',
+    '  prune <name>      Delete stale branches from the remote',
+    '  list              Show existing remotes                    [default]',
+    '',
+    'Options:',
+    '  --help  Show help                         [commands: help] [boolean]'
+  ].join('\n'))
 
-  promises.push(api.parse('help remote add').then(result => {
-    t.equal(result.code, 0)
-    t.equal(result.errors.length, 0)
-    t.equal(result.output, [
-      'Usage: nug remote add <name> <url> [options]',
-      '',
-      'Arguments:',
-      '  <name>  The name of the new remote               [required] [string]',
-      '  <url>   The url of the new remote                [required] [string]',
-      '',
-      'Options:',
-      '  --help  Show help                         [commands: help] [boolean]'
-    ].join('\n'))
-  }))
+  t.equal(result3.code, 0)
+  t.equal(result3.errors.length, 0)
+  t.equal(result3.output, [
+    'Usage: nug remote add <name> <url> [options]',
+    '',
+    'Arguments:',
+    '  <name>  The name of the new remote               [required] [string]',
+    '  <url>   The url of the new remote                [required] [string]',
+    '',
+    'Options:',
+    '  --help  Show help                         [commands: help] [boolean]'
+  ].join('\n'))
 
-  promises.push(api.parse('remote --help add').then(result => {
-    t.equal(result.code, 0)
-    t.equal(result.errors.length, 0)
-    t.equal(result.output, [
-      'Usage: nug remote add <name> <url> [options]',
-      '',
-      'Arguments:',
-      '  <name>  The name of the new remote               [required] [string]',
-      '  <url>   The url of the new remote                [required] [string]',
-      '',
-      'Options:',
-      '  --help  Show help                         [commands: help] [boolean]'
-    ].join('\n'))
-  }))
+  t.equal(result4.code, 0)
+  t.equal(result4.errors.length, 0)
+  t.equal(result4.output, [
+    'Usage: nug remote add <name> <url> [options]',
+    '',
+    'Arguments:',
+    '  <name>  The name of the new remote               [required] [string]',
+    '  <url>   The url of the new remote                [required] [string]',
+    '',
+    'Options:',
+    '  --help  Show help                         [commands: help] [boolean]'
+  ].join('\n'))
 
-  promises.push(api.parse('remote prune --help').then(result => {
-    t.equal(result.code, 0)
-    t.equal(result.errors.length, 0)
-    t.equal(result.output, [
-      'Usage: nug remote prune <name> [options]',
-      '',
-      'Arguments:',
-      '  <name>  The name of the remote                   [required] [string]',
-      '',
-      'Options:',
-      '  --help  Show help                         [commands: help] [boolean]'
-    ].join('\n'))
-  }))
+  t.equal(result5.code, 0)
+  t.equal(result5.errors.length, 0)
+  t.equal(result5.output, [
+    'Usage: nug remote prune <name> [options]',
+    '',
+    'Arguments:',
+    '  <name>  The name of the remote                   [required] [string]',
+    '',
+    'Options:',
+    '  --help  Show help                         [commands: help] [boolean]'
+  ].join('\n'))
 
-  promises.push(api.parse('--help remote list').then(result => {
-    t.equal(result.code, 0)
-    t.equal(result.errors.length, 0)
-    t.equal(result.output, [
-      'Usage: nug remote list [options]',
-      '',
-      'Options:',
-      '  -v, --verbose  Include urls                                [boolean]',
-      '  --help         Show help                  [commands: help] [boolean]'
-    ].join('\n'))
-  }))
+  t.equal(result6.code, 0)
+  t.equal(result6.errors.length, 0)
+  t.equal(result6.output, [
+    'Usage: nug remote list [options]',
+    '',
+    'Options:',
+    '  -v, --verbose  Include urls                                [boolean]',
+    '  --help         Show help                  [commands: help] [boolean]'
+  ].join('\n'))
 
-  promises.push(api.parse('stash').then(result => {
-    t.equal(result.code, 0)
-    t.equal(result.errors.length, 0)
-    t.equal(result.output, [
-      'Usage: nug stash <command> <args> [options]',
-      '',
-      'Commands:',
-      '  list          List saved stashes',
-      '  show [stash]  Show stored changes',
-      '  save [msg]    Store changes as a new stash',
-      '',
-      'Options:',
-      '  --help  Show help                         [commands: help] [boolean]'
-    ].join('\n'))
-  }))
+  t.equal(result7.code, 0)
+  t.equal(result7.errors.length, 0)
+  t.equal(result7.output, [
+    'Usage: nug stash <command> <args> [options]',
+    '',
+    'Commands:',
+    '  list          List saved stashes',
+    '  show [stash]  Show stored changes',
+    '  save [msg]    Store changes as a new stash',
+    '',
+    'Options:',
+    '  --help  Show help                         [commands: help] [boolean]'
+  ].join('\n'))
 
-  promises.push(api.parse('help stash list').then(result => {
-    t.equal(result.code, 0)
-    t.equal(result.errors.length, 0)
-    t.equal(result.output, [
-      'Usage: nug stash list [options]',
-      '',
-      'Options:',
-      '  --help  Show help                         [commands: help] [boolean]'
-    ].join('\n'))
-  }))
+  t.equal(result8.code, 0)
+  t.equal(result8.errors.length, 0)
+  t.equal(result8.output, [
+    'Usage: nug stash list [options]',
+    '',
+    'Options:',
+    '  --help  Show help                         [commands: help] [boolean]'
+  ].join('\n'))
 
-  promises.push(api.parse('stash --help show').then(result => {
-    t.equal(result.code, 0)
-    t.equal(result.errors.length, 0)
-    t.equal(result.output, [
-      'Usage: nug stash show [stash] [options]',
-      '',
-      'Arguments:',
-      '  [stash]  The id of the stash to show                        [string]',
-      '',
-      'Options:',
-      '  --help  Show help                         [commands: help] [boolean]'
-    ].join('\n'))
-  }))
+  t.equal(result9.code, 0)
+  t.equal(result9.errors.length, 0)
+  t.equal(result9.output, [
+    'Usage: nug stash show [stash] [options]',
+    '',
+    'Arguments:',
+    '  [stash]  The id of the stash to show                        [string]',
+    '',
+    'Options:',
+    '  --help  Show help                         [commands: help] [boolean]'
+  ].join('\n'))
 
-  promises.push(api.parse('stash save --help').then(result => {
-    t.equal(result.code, 0)
-    t.equal(result.errors.length, 0)
-    t.equal(result.output, [
-      'Usage: nug stash save [msg] [options]',
-      '',
-      'Arguments:',
-      '  [msg]  An optional message to describe the stash            [string]',
-      '',
-      'Options:',
-      '  -u, --untracked  Include untracked changes                 [boolean]',
-      '  --help           Show help                [commands: help] [boolean]'
-    ].join('\n'))
-  }))
+  t.equal(result10.code, 0)
+  t.equal(result10.errors.length, 0)
+  t.equal(result10.output, [
+    'Usage: nug stash save [msg] [options]',
+    '',
+    'Arguments:',
+    '  [msg]  An optional message to describe the stash            [string]',
+    '',
+    'Options:',
+    '  -u, --untracked  Include untracked changes                 [boolean]',
+    '  --help           Show help                [commands: help] [boolean]'
+  ].join('\n'))
 
-  promises.push(api.parse('help stash').then(result => {
-    t.equal(result.code, 0)
-    t.equal(result.errors.length, 0)
-    t.equal(result.output, [
-      'Usage: nug stash <command> <args> [options]',
-      '',
-      'Commands:',
-      '  list          List saved stashes',
-      '  show [stash]  Show stored changes',
-      '  save [msg]    Store changes as a new stash',
-      '',
-      'Options:',
-      '  --help  Show help                         [commands: help] [boolean]'
-    ].join('\n'))
-  }))
-
-  return Promise.all(promises)
+  t.equal(result11.code, 0)
+  t.equal(result11.errors.length, 0)
+  t.equal(result11.output, [
+    'Usage: nug stash <command> <args> [options]',
+    '',
+    'Commands:',
+    '  list          List saved stashes',
+    '  show [stash]  Show stored changes',
+    '  save [msg]    Store changes as a new stash',
+    '',
+    'Options:',
+    '  --help  Show help                         [commands: help] [boolean]'
+  ].join('\n'))
 })
 
-tap.test('command > supports aliases', t => {
+tap.test('command > supports aliases', async t => {
   let setupCalled = 0
   let runCalled = 0
   const opts = {
@@ -469,46 +457,47 @@ tap.test('command > supports aliases', t => {
   t.same(opts.aliases, ['gopher', 'punch', 'hit'])
   t.equal(typeof opts.setup, 'function')
   t.equal(typeof opts.run, 'function')
-  const promises = []
-  promises.push(api.parse('do something').then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.it, 'something')
-    t.same(result.argv._, [])
-    assertTypeDetails(t, result, 0, ['_'], 'array:string', [], 'default', [], [])
-    assertTypeDetails(t, result, 1, ['do', 'gopher', 'punch', 'hit'], 'command', true, 'positional', [0], ['do'])
-    Helper.get(`${parent} do`).assertTypeDetails(t, result, 2, ['it'], 'string', 'something', 'positional', [1], ['something'])
-  }))
-  promises.push(api.parse('gopher it').then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.it, 'it')
-    t.same(result.argv._, [])
-    assertTypeDetails(t, result, 0, ['_'], 'array:string', [], 'default', [], [])
-    assertTypeDetails(t, result, 1, ['do', 'gopher', 'punch', 'hit'], 'command', true, 'positional', [0], ['gopher'])
-    Helper.get(`${parent} do`).assertTypeDetails(t, result, 2, ['it'], 'string', 'it', 'positional', [1], ['it'])
-  }))
-  promises.push(api.parse('punch dat').then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.it, 'dat')
-    t.same(result.argv._, [])
-    assertTypeDetails(t, result, 0, ['_'], 'array:string', [], 'default', [], [])
-    assertTypeDetails(t, result, 1, ['do', 'gopher', 'punch', 'hit'], 'command', true, 'positional', [0], ['punch'])
-    Helper.get(`${parent} do`).assertTypeDetails(t, result, 2, ['it'], 'string', 'dat', 'positional', [1], ['dat'])
-  }))
-  promises.push(api.parse('hit up').then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.it, 'up')
-    t.same(result.argv._, [])
-    assertTypeDetails(t, result, 0, ['_'], 'array:string', [], 'default', [], [])
-    assertTypeDetails(t, result, 1, ['do', 'gopher', 'punch', 'hit'], 'command', true, 'positional', [0], ['hit'])
-    Helper.get(`${parent} do`).assertTypeDetails(t, result, 2, ['it'], 'string', 'up', 'positional', [1], ['up'])
-  }))
-  return Promise.all(promises).then(whenDone => {
-    t.equal(setupCalled, 1)
-    t.equal(runCalled, 4)
-  })
+
+  const [result1, result2, result3, result4] = await Promise.all([
+    api.parse('do something'),
+    api.parse('gopher it'),
+    api.parse('punch dat'),
+    api.parse('hit up')
+  ])
+
+  assertNoErrors(t, result1)
+  t.equal(result1.argv.it, 'something')
+  t.same(result1.argv._, [])
+  assertTypeDetails(t, result1, 0, ['_'], 'array:string', [], 'default', [], [])
+  assertTypeDetails(t, result1, 1, ['do', 'gopher', 'punch', 'hit'], 'command', true, 'positional', [0], ['do'])
+  Helper.get(`${parent} do`).assertTypeDetails(t, result1, 2, ['it'], 'string', 'something', 'positional', [1], ['something'])
+
+  assertNoErrors(t, result2)
+  t.equal(result2.argv.it, 'it')
+  t.same(result2.argv._, [])
+  assertTypeDetails(t, result2, 0, ['_'], 'array:string', [], 'default', [], [])
+  assertTypeDetails(t, result2, 1, ['do', 'gopher', 'punch', 'hit'], 'command', true, 'positional', [0], ['gopher'])
+  Helper.get(`${parent} do`).assertTypeDetails(t, result2, 2, ['it'], 'string', 'it', 'positional', [1], ['it'])
+
+  assertNoErrors(t, result3)
+  t.equal(result3.argv.it, 'dat')
+  t.same(result3.argv._, [])
+  assertTypeDetails(t, result3, 0, ['_'], 'array:string', [], 'default', [], [])
+  assertTypeDetails(t, result3, 1, ['do', 'gopher', 'punch', 'hit'], 'command', true, 'positional', [0], ['punch'])
+  Helper.get(`${parent} do`).assertTypeDetails(t, result3, 2, ['it'], 'string', 'dat', 'positional', [1], ['dat'])
+
+  assertNoErrors(t, result4)
+  t.equal(result4.argv.it, 'up')
+  t.same(result4.argv._, [])
+  assertTypeDetails(t, result4, 0, ['_'], 'array:string', [], 'default', [], [])
+  assertTypeDetails(t, result4, 1, ['do', 'gopher', 'punch', 'hit'], 'command', true, 'positional', [0], ['hit'])
+  Helper.get(`${parent} do`).assertTypeDetails(t, result4, 2, ['it'], 'string', 'up', 'positional', [1], ['up'])
+
+  t.equal(setupCalled, 1)
+  t.equal(runCalled, 4)
 })
 
-tap.test('command > default command with other alias', t => {
+tap.test('command > default command with other alias', async t => {
   let runCalled = 0
   let innerArgv
   const api = Api.get()
@@ -520,21 +509,21 @@ tap.test('command > default command with other alias', t => {
         runCalled++
       }
     })
-  return api.parse('').then(result => {
-    assertNoErrors(t, result)
-    t.equal(runCalled, 1)
-    t.same(innerArgv && innerArgv._, [])
-    return api.parse('one -x y -b')
-  }).then(result => {
-    assertNoErrors(t, result)
-    t.equal(runCalled, 2)
-    t.same(innerArgv && innerArgv._, [])
-    t.equal(innerArgv && innerArgv.x, 'y')
-    t.equal(innerArgv && innerArgv.b, true)
-  })
+
+  let result = await api.parse('')
+  assertNoErrors(t, result)
+  t.equal(runCalled, 1)
+  t.same(innerArgv && innerArgv._, [])
+
+  result = await api.parse('one -x y -b')
+  assertNoErrors(t, result)
+  t.equal(runCalled, 2)
+  t.same(innerArgv && innerArgv._, [])
+  t.equal(innerArgv && innerArgv.x, 'y')
+  t.equal(innerArgv && innerArgv.b, true)
 })
 
-tap.test('command > default command with no alias', t => {
+tap.test('command > default command with no alias', async t => {
   let runCalled = 0
   let innerArgv
   const api = Api.get()
@@ -543,57 +532,54 @@ tap.test('command > default command with no alias', t => {
       innerArgv = argv
       runCalled++
     })
-  return api.parse('').then(result => {
-    assertNoErrors(t, result)
-    t.equal(runCalled, 1)
-    t.same(innerArgv && innerArgv._, [])
-    return api.parse('one -x y -b')
-  }).then(result => {
-    assertNoErrors(t, result)
-    t.equal(runCalled, 2)
-    t.same(innerArgv && innerArgv._, ['one'])
-    t.equal(innerArgv && innerArgv.x, 'y')
-    t.equal(innerArgv && innerArgv.b, true)
-  })
+
+  let result = await api.parse('')
+  assertNoErrors(t, result)
+  t.equal(runCalled, 1)
+  t.same(innerArgv && innerArgv._, [])
+
+  result = await api.parse('one -x y -b')
+  assertNoErrors(t, result)
+  t.equal(runCalled, 2)
+  t.same(innerArgv && innerArgv._, ['one'])
+  t.equal(innerArgv && innerArgv.x, 'y')
+  t.equal(innerArgv && innerArgv.b, true)
 })
 
-tap.test('command > run handler > adding cli message affects result', t => {
-  return Api.get()
+tap.test('command > run handler > adding cli message affects result', async t => {
+  const result = await Api.get()
     .command('fail', (argv, context) => {
       context.cliMessage('You broke it')
     })
-    .parse('fail').then(result => {
-      t.equal(result.code, 1)
-      t.match(result.output, /You broke it/)
-      t.equal(result.errors.length, 0)
-    })
+    .parse('fail')
+  t.equal(result.code, 1)
+  t.match(result.output, /You broke it/)
+  t.equal(result.errors.length, 0)
 })
 
-tap.test('command > run handler > throwing error affects result', t => {
-  return Api.get()
+tap.test('command > run handler > throwing error affects result', async t => {
+  const result = await Api.get()
     .command('throw', argv => {
       throw new Error('Thrown')
     })
-    .parse('throw').then(result => {
-      t.equal(result.code, 1)
-      t.match(result.output, /Thrown/)
-      t.equal(result.errors.length, 1)
-    })
+    .parse('throw')
+  t.equal(result.code, 1)
+  t.match(result.output, /Thrown/)
+  t.equal(result.errors.length, 1)
 })
 
-tap.test('command > run handler > rejecting promise affects result', t => {
-  return Api.get()
+tap.test('command > run handler > rejecting promise affects result', async t => {
+  const result = await Api.get()
     .command('reject', argv => Promise.reject(new Error('Rejected')))
-    .parse('reject').then(result => {
-      t.equal(result.code, 1)
-      t.match(result.output, /Rejected/)
-      t.equal(result.errors.length, 1)
-    })
+    .parse('reject')
+  t.equal(result.code, 1)
+  t.match(result.output, /Rejected/)
+  t.equal(result.errors.length, 1)
 })
 
-tap.test('command > run handler > result not returned until handler resolves', t => {
+tap.test('command > run handler > result not returned until handler resolves', async t => {
   let done = false
-  return Api.get().command('wait [ms:number=1000]', argv => {
+  await Api.get().command('wait [ms:number=1000]', argv => {
     t.equal(argv.ms, 1000)
     return new Promise(resolve => {
       setTimeout(() => {
@@ -601,7 +587,6 @@ tap.test('command > run handler > result not returned until handler resolves', t
         resolve()
       }, argv.ms)
     })
-  }).parse('wait').then(result => {
-    t.equal(done, true)
-  })
+  }).parse('wait')
+  t.equal(done, true)
 })

--- a/test/types/test-help.js
+++ b/test/types/test-help.js
@@ -9,7 +9,7 @@ const helper = require('../helper').get(parent)
 const assertNoErrors = helper.assertNoErrors.bind(helper)
 const assertTypeDetails = helper.assertTypeDetails.bind(helper)
 
-tap.test('help > defaults', t => {
+tap.test('help > defaults', async t => {
   const api = Api.get().help()
   const typeObjects = api.initContext(true).types
   t.same(typeObjects[parent][0].aliases, ['help'])
@@ -19,18 +19,17 @@ tap.test('help > defaults', t => {
   t.equal(typeObjects[parent][0].helpHints, '[commands: help] [boolean]')
   t.equal(typeObjects[parent][0].helpGroup, 'Options:')
   t.equal(typeObjects[parent][0].isHidden, false)
-  return api.parse('--help').then(result => {
-    t.equal(result.code, 0)
-    t.equal(result.output, [
-      `Usage: ${parent} [options]`,
-      '',
-      'Options:',
-      '  --help  Show help                                                       [commands: help] [boolean]'
-    ].join('\n'))
-    t.equal(result.errors.length, 0)
-    t.equal(result.argv.help, true)
-    assertTypeDetails(t, result, 1, ['help'], 'boolean', true, 'flag', [0], ['--help'])
-  })
+  const result = await api.parse('--help')
+  t.equal(result.code, 0)
+  t.equal(result.output, [
+    `Usage: ${parent} [options]`,
+    '',
+    'Options:',
+    '  --help  Show help                                                       [commands: help] [boolean]'
+  ].join('\n'))
+  t.equal(result.errors.length, 0)
+  t.equal(result.argv.help, true)
+  assertTypeDetails(t, result, 1, ['help'], 'boolean', true, 'flag', [0], ['--help'])
 })
 
 tap.test('help > custom flags, desc, group, hints', t => {
@@ -65,60 +64,59 @@ tap.test('help > custom flags, desc, group, hints', t => {
   t.end()
 })
 
-tap.test('help > default implicit command', t => {
+tap.test('help > default implicit command', async t => {
   const api = Api.get().help()
-  return api.parse('help').then(result => {
-    t.equal(result.code, 0)
-    t.equal(result.output, [
-      `Usage: ${parent} [options]`,
-      '',
-      'Options:',
-      '  --help  Show help                                                       [commands: help] [boolean]'
-    ].join('\n'))
-    t.equal(result.errors.length, 0)
-    t.equal(result.argv.help, true)
-    assertTypeDetails(t, result, 1, ['help'], 'boolean', true, 'positional', [0], ['help'])
-    return api.parse('not help')
-  }).then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.help, false)
-    t.same(result.argv._, ['not', 'help'])
-    assertTypeDetails(t, result, 0, ['_'], 'array:string', ['not', 'help'], 'positional', [0, 1], ['not', 'help'])
-    assertTypeDetails(t, result, 1, ['help'], 'boolean', false, 'default', [], [])
-  })
+
+  let result = await api.parse('help')
+  t.equal(result.code, 0)
+  t.equal(result.output, [
+    `Usage: ${parent} [options]`,
+    '',
+    'Options:',
+    '  --help  Show help                                                       [commands: help] [boolean]'
+  ].join('\n'))
+  t.equal(result.errors.length, 0)
+  t.equal(result.argv.help, true)
+  assertTypeDetails(t, result, 1, ['help'], 'boolean', true, 'positional', [0], ['help'])
+
+  result = await api.parse('not help')
+  assertNoErrors(t, result)
+  t.equal(result.argv.help, false)
+  t.same(result.argv._, ['not', 'help'])
+  assertTypeDetails(t, result, 0, ['_'], 'array:string', ['not', 'help'], 'positional', [0, 1], ['not', 'help'])
+  assertTypeDetails(t, result, 1, ['help'], 'boolean', false, 'default', [], [])
 })
 
-tap.test('help > custom implicit command via flags', t => {
+tap.test('help > custom implicit command via flags', async t => {
   const api = Api.get().help('-H | --get-help')
-  return api.parse('get-help').then(result => {
-    t.equal(result.code, 0)
-    t.equal(result.output, [
-      `Usage: ${parent} [options]`,
-      '',
-      'Options:',
-      '  -H | --get-help  Show help                                          [commands: get-help] [boolean]'
-    ].join('\n'))
-    t.equal(result.errors.length, 0)
-    t.equal(result.argv.H, true)
-    t.equal(result.argv['get-help'], true)
-    assertTypeDetails(t, result, 1, ['H', 'get-help'], 'boolean', true, 'positional', [0], ['get-help'])
-    return api.parse('H')
-  }).then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.H, false)
-    t.equal(result.argv['get-help'], false)
-    t.same(result.argv._, ['H'])
-    assertTypeDetails(t, result, 0, ['_'], 'array:string', ['H'], 'positional', [0], ['H'])
-    assertTypeDetails(t, result, 1, ['H', 'get-help'], 'boolean', false, 'default', [], [])
-  })
+
+  let result = await api.parse('get-help')
+  t.equal(result.code, 0)
+  t.equal(result.output, [
+    `Usage: ${parent} [options]`,
+    '',
+    'Options:',
+    '  -H | --get-help  Show help                                          [commands: get-help] [boolean]'
+  ].join('\n'))
+  t.equal(result.errors.length, 0)
+  t.equal(result.argv.H, true)
+  t.equal(result.argv['get-help'], true)
+  assertTypeDetails(t, result, 1, ['H', 'get-help'], 'boolean', true, 'positional', [0], ['get-help'])
+
+  result = await api.parse('H')
+  assertNoErrors(t, result)
+  t.equal(result.argv.H, false)
+  t.equal(result.argv['get-help'], false)
+  t.same(result.argv._, ['H'])
+  assertTypeDetails(t, result, 0, ['_'], 'array:string', ['H'], 'positional', [0], ['H'])
+  assertTypeDetails(t, result, 1, ['H', 'get-help'], 'boolean', false, 'default', [], [])
 })
 
-tap.test('help > disable implicit command', t => {
-  return Api.get().help({ implicitCommand: false }).parse('help').then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.help, false)
-    t.same(result.argv._, ['help'])
-    assertTypeDetails(t, result, 0, ['_'], 'array:string', ['help'], 'positional', [0], ['help'])
-    assertTypeDetails(t, result, 1, ['help'], 'boolean', false, 'default', [], [])
-  })
+tap.test('help > disable implicit command', async t => {
+  const result = await Api.get().help({ implicitCommand: false }).parse('help')
+  assertNoErrors(t, result)
+  t.equal(result.argv.help, false)
+  t.same(result.argv._, ['help'])
+  assertTypeDetails(t, result, 0, ['_'], 'array:string', ['help'], 'positional', [0], ['help'])
+  assertTypeDetails(t, result, 1, ['help'], 'boolean', false, 'default', [], [])
 })

--- a/test/types/test-path.js
+++ b/test/types/test-path.js
@@ -13,165 +13,161 @@ const SLASH = path.sep
 const DIRBASENAME = path.basename(__dirname)
 const DNE = 'blerg_dne'
 
-tap.test('path > mustExist true', t => {
+tap.test('path > mustExist true', async t => {
   const api = Api.get().path('-p, --path', { mustExist: true })
-  return api.parse(`-p ${__filename}`).then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.p, __filename)
-    t.equal(result.argv.path, __filename)
-    assertTypeDetails(t, result, 1, ['p', 'path'], 'path', __filename, 'flag', [0, 1], ['-p', __filename])
-    return api.parse(`-p ${__dirname}`)
-  }).then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.p, __dirname)
-    t.equal(result.argv.path, __dirname)
-    assertTypeDetails(t, result, 1, ['p', 'path'], 'path', __dirname, 'flag', [0, 1], ['-p', __dirname])
-    return api.parse(`-p ${DNE}`)
-  }).then(result => {
-    t.equal(result.code, 1)
-    t.match(result.output, new RegExp(`The path does not exist: ${DNE}`))
-    t.equal(result.errors.length, 0)
-  })
+
+  let result = await api.parse(`-p ${__filename}`)
+  assertNoErrors(t, result)
+  t.equal(result.argv.p, __filename)
+  t.equal(result.argv.path, __filename)
+  assertTypeDetails(t, result, 1, ['p', 'path'], 'path', __filename, 'flag', [0, 1], ['-p', __filename])
+
+  result = await api.parse(`-p ${__dirname}`)
+  assertNoErrors(t, result)
+  t.equal(result.argv.p, __dirname)
+  t.equal(result.argv.path, __dirname)
+  assertTypeDetails(t, result, 1, ['p', 'path'], 'path', __dirname, 'flag', [0, 1], ['-p', __dirname])
+
+  result = await api.parse(`-p ${DNE}`)
+  t.equal(result.code, 1)
+  t.match(result.output, new RegExp(`The path does not exist: ${DNE}`))
+  t.equal(result.errors.length, 0)
 })
 
-tap.test('path > mustExist false', t => {
+tap.test('path > mustExist false', async t => {
   const api = Api.get().path('-p, --path', { mustExist: false })
-  return api.parse(`-p ${__filename}`).then(result => {
-    t.equal(result.code, 1)
-    t.match(result.output, new RegExp(`The file already exists: ${__filename}`))
-    t.equal(result.errors.length, 0)
-    return api.parse(`-p ${__dirname}`)
-  }).then(result => {
-    t.equal(result.code, 1)
-    t.match(result.output, new RegExp(`The directory already exists: ${__dirname}`))
-    t.equal(result.errors.length, 0)
-    return api.parse(`-p ${DNE}`)
-  }).then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.p, DNE)
-    t.equal(result.argv.path, DNE)
-    assertTypeDetails(t, result, 1, ['p', 'path'], 'path', DNE, 'flag', [0, 1], ['-p', DNE])
-  })
+
+  let result = await api.parse(`-p ${__filename}`)
+  t.equal(result.code, 1)
+  t.match(result.output, new RegExp(`The file already exists: ${__filename}`))
+  t.equal(result.errors.length, 0)
+
+  result = await api.parse(`-p ${__dirname}`)
+  t.equal(result.code, 1)
+  t.match(result.output, new RegExp(`The directory already exists: ${__dirname}`))
+  t.equal(result.errors.length, 0)
+
+  result = await api.parse(`-p ${DNE}`)
+  assertNoErrors(t, result)
+  t.equal(result.argv.p, DNE)
+  t.equal(result.argv.path, DNE)
+  assertTypeDetails(t, result, 1, ['p', 'path'], 'path', DNE, 'flag', [0, 1], ['-p', DNE])
 })
 
-tap.test('file > mustExist true', t => {
+tap.test('file > mustExist true', async t => {
   const api = Api.get().file('-f, --file', { mustExist: true })
-  return api.parse(`-f ${__filename}`).then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.f, __filename)
-    t.equal(result.argv.file, __filename)
-    assertTypeDetails(t, result, 1, ['f', 'file'], 'file', __filename, 'flag', [0, 1], ['-f', __filename])
-    return api.parse(`-f ${__dirname}`)
-  }).then(result => {
-    t.equal(result.code, 1)
-    t.match(result.output, new RegExp(`The path is a directory: ${__dirname}`))
-    t.equal(result.errors.length, 0)
-    return api.parse(`-f ${DNE}`)
-  }).then(result => {
-    t.equal(result.code, 1)
-    t.match(result.output, new RegExp(`The file does not exist: ${DNE}`))
-    t.equal(result.errors.length, 0)
-  })
+
+  let result = await api.parse(`-f ${__filename}`)
+  assertNoErrors(t, result)
+  t.equal(result.argv.f, __filename)
+  t.equal(result.argv.file, __filename)
+  assertTypeDetails(t, result, 1, ['f', 'file'], 'file', __filename, 'flag', [0, 1], ['-f', __filename])
+
+  result = await api.parse(`-f ${__dirname}`)
+  t.equal(result.code, 1)
+  t.match(result.output, new RegExp(`The path is a directory: ${__dirname}`))
+  t.equal(result.errors.length, 0)
+
+  result = await api.parse(`-f ${DNE}`)
+  t.equal(result.code, 1)
+  t.match(result.output, new RegExp(`The file does not exist: ${DNE}`))
+  t.equal(result.errors.length, 0)
 })
 
-tap.test('file > mustExist false', t => {
+tap.test('file > mustExist false', async t => {
   const api = Api.get().file('-f, --file', { mustExist: false })
-  return api.parse(`-f ${__filename}`).then(result => {
-    t.equal(result.code, 1)
-    t.match(result.output, new RegExp(`The file already exists: ${__filename}`))
-    t.equal(result.errors.length, 0)
-    return api.parse(`-f ${__dirname}`)
-  }).then(result => {
-    t.equal(result.code, 1)
-    t.match(result.output, new RegExp(`The path exists and is a directory: ${__dirname}`))
-    t.equal(result.errors.length, 0)
-    return api.parse(`-f ${DNE}`)
-  }).then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.f, DNE)
-    t.equal(result.argv.file, DNE)
-    assertTypeDetails(t, result, 1, ['f', 'file'], 'file', DNE, 'flag', [0, 1], ['-f', DNE])
-  })
+
+  let result = await api.parse(`-f ${__filename}`)
+  t.equal(result.code, 1)
+  t.match(result.output, new RegExp(`The file already exists: ${__filename}`))
+  t.equal(result.errors.length, 0)
+
+  result = await api.parse(`-f ${__dirname}`)
+  t.equal(result.code, 1)
+  t.match(result.output, new RegExp(`The path exists and is a directory: ${__dirname}`))
+  t.equal(result.errors.length, 0)
+
+  result = await api.parse(`-f ${DNE}`)
+  assertNoErrors(t, result)
+  t.equal(result.argv.f, DNE)
+  t.equal(result.argv.file, DNE)
+  assertTypeDetails(t, result, 1, ['f', 'file'], 'file', DNE, 'flag', [0, 1], ['-f', DNE])
 })
 
-tap.test('dir > mustExist true', t => {
+tap.test('dir > mustExist true', async t => {
   const api = Api.get().dir('-d, --dir', { mustExist: true })
-  return api.parse(`-d ${__filename}`).then(result => {
-    t.equal(result.code, 1)
-    t.match(result.output, new RegExp(`The path is a file: ${__filename}`))
-    t.equal(result.errors.length, 0)
-    return api.parse(`-d ${__dirname}`)
-  }).then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.d, __dirname)
-    t.equal(result.argv.dir, __dirname)
-    assertTypeDetails(t, result, 1, ['d', 'dir'], 'dir', __dirname, 'flag', [0, 1], ['-d', __dirname])
-    return api.parse(`-d ${DNE}`)
-  }).then(result => {
-    t.equal(result.code, 1)
-    t.match(result.output, new RegExp(`The directory does not exist: ${DNE}`))
-    t.equal(result.errors.length, 0)
-  })
+
+  let result = await api.parse(`-d ${__filename}`)
+  t.equal(result.code, 1)
+  t.match(result.output, new RegExp(`The path is a file: ${__filename}`))
+  t.equal(result.errors.length, 0)
+
+  result = await api.parse(`-d ${__dirname}`)
+  assertNoErrors(t, result)
+  t.equal(result.argv.d, __dirname)
+  t.equal(result.argv.dir, __dirname)
+  assertTypeDetails(t, result, 1, ['d', 'dir'], 'dir', __dirname, 'flag', [0, 1], ['-d', __dirname])
+
+  result = await api.parse(`-d ${DNE}`)
+  t.equal(result.code, 1)
+  t.match(result.output, new RegExp(`The directory does not exist: ${DNE}`))
+  t.equal(result.errors.length, 0)
 })
 
-tap.test('dir > mustExist false', t => {
+tap.test('dir > mustExist false', async t => {
   const api = Api.get().dir('-d, --dir', { mustExist: false })
-  return api.parse(`-d ${__filename}`).then(result => {
-    t.equal(result.code, 1)
-    t.match(result.output, new RegExp(`The path exists and is a file: ${__filename}`))
-    t.equal(result.errors.length, 0)
-    return api.parse(`-d ${__dirname}`)
-  }).then(result => {
-    t.equal(result.code, 1)
-    t.match(result.output, new RegExp(`The directory already exists: ${__dirname}`))
-    t.equal(result.errors.length, 0)
-    return api.parse(`-d ${DNE}`)
-  }).then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.d, DNE)
-    t.equal(result.argv.dir, DNE)
-    assertTypeDetails(t, result, 1, ['d', 'dir'], 'dir', DNE, 'flag', [0, 1], ['-d', DNE])
-  })
+
+  let result = await api.parse(`-d ${__filename}`)
+  t.equal(result.code, 1)
+  t.match(result.output, new RegExp(`The path exists and is a file: ${__filename}`))
+  t.equal(result.errors.length, 0)
+
+  result = await api.parse(`-d ${__dirname}`)
+  t.equal(result.code, 1)
+  t.match(result.output, new RegExp(`The directory already exists: ${__dirname}`))
+  t.equal(result.errors.length, 0)
+
+  result = await api.parse(`-d ${DNE}`)
+  assertNoErrors(t, result)
+  t.equal(result.argv.d, DNE)
+  t.equal(result.argv.dir, DNE)
+  assertTypeDetails(t, result, 1, ['d', 'dir'], 'dir', DNE, 'flag', [0, 1], ['-d', DNE])
 })
 
-tap.test('path > normalize', t => {
+tap.test('path > normalize', async t => {
   const dirnameEquivalent = `${__dirname}${SLASH}..${SLASH}${DIRBASENAME}`
-  return Api.get().path('-p, --path', { normalize: true }).parse(`-p ${dirnameEquivalent}`).then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.p, __dirname)
-    t.equal(result.argv.path, __dirname)
-    assertTypeDetails(t, result, 1, ['p', 'path'], 'path', __dirname, 'flag', [0, 1], ['-p', dirnameEquivalent])
-  })
+  const result = await Api.get().path('-p, --path', { normalize: true }).parse(`-p ${dirnameEquivalent}`)
+  assertNoErrors(t, result)
+  t.equal(result.argv.p, __dirname)
+  t.equal(result.argv.path, __dirname)
+  assertTypeDetails(t, result, 1, ['p', 'path'], 'path', __dirname, 'flag', [0, 1], ['-p', dirnameEquivalent])
 })
 
-tap.test('path > normalize asWin32', t => {
+tap.test('path > normalize asWin32', async t => {
   const dirnamePosix = __dirname.split(SLASH).join('/')
   const dirnameWin32 = __dirname.split(SLASH).join('\\')
-  return Api.get().path('-p, --path', { normalize: true, asWin32: true }).parse(`-p ${dirnamePosix}`).then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.p, dirnameWin32)
-    t.equal(result.argv.path, dirnameWin32)
-    assertTypeDetails(t, result, 1, ['p', 'path'], 'path', dirnameWin32, 'flag', [0, 1], ['-p', dirnamePosix])
-  })
+  const result = await Api.get().path('-p, --path', { normalize: true, asWin32: true }).parse(`-p ${dirnamePosix}`)
+  assertNoErrors(t, result)
+  t.equal(result.argv.p, dirnameWin32)
+  t.equal(result.argv.path, dirnameWin32)
+  assertTypeDetails(t, result, 1, ['p', 'path'], 'path', dirnameWin32, 'flag', [0, 1], ['-p', dirnamePosix])
 })
 
-tap.test('path > asObject', t => {
-  return Api.get().path('-p', { asObject: true }).parse(`-p ${__filename}`).then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.p && result.argv.p.dir, __dirname)
-    t.equal(result.argv.p && result.argv.p.base, `${parent}.js`)
-    t.equal(result.argv.p && result.argv.p.ext, '.js')
-    t.equal(result.argv.p && result.argv.p.name, parent)
-  })
+tap.test('path > asObject', async t => {
+  const result = await Api.get().path('-p', { asObject: true }).parse(`-p ${__filename}`)
+  assertNoErrors(t, result)
+  t.equal(result.argv.p && result.argv.p.dir, __dirname)
+  t.equal(result.argv.p && result.argv.p.base, `${parent}.js`)
+  t.equal(result.argv.p && result.argv.p.ext, '.js')
+  t.equal(result.argv.p && result.argv.p.name, parent)
 })
 
-tap.test('path > validate default value in strict mode', t => {
-  return Api.get().path('-p <path>', {
+tap.test('path > validate default value in strict mode', async t => {
+  const result = await Api.get().path('-p <path>', {
     defaultValue: DNE,
     mustExist: true
-  }).parse('').then(result => {
-    t.equal(result.code, 1)
-    t.match(result.output, new RegExp(`The path does not exist: ${DNE}`))
-    t.equal(result.errors.length, 0)
-  })
+  }).parse('')
+  t.equal(result.code, 1)
+  t.match(result.output, new RegExp(`The path does not exist: ${DNE}`))
+  t.equal(result.errors.length, 0)
 })

--- a/test/types/test-positional.js
+++ b/test/types/test-positional.js
@@ -9,264 +9,254 @@ const helper = require('../helper').get(parent)
 const assertNoErrors = helper.assertNoErrors.bind(helper)
 const assertTypeDetails = helper.assertTypeDetails.bind(helper)
 
-tap.test('positional > basic dsl', t => {
+tap.test('positional > basic dsl', async t => {
   const api = Api.get().positional('<name> [url]')
-  return api.parse('one two').then(result => {
-    assertNoErrors(t, result)
 
-    t.equal(result.argv.name, 'one')
-    t.equal(result.argv.url, 'two')
-    t.same(result.argv._, [])
-    t.same(result.details.args, ['one', 'two'])
-    t.equal(result.details.types.length, 3)
+  let result = await api.parse('one two')
+  assertNoErrors(t, result)
 
-    assertTypeDetails(t, result, 0, ['_'], 'array:string', [], 'default', [], [])
-    assertTypeDetails(t, result, 1, ['name'], 'string', 'one', 'positional', [0], ['one'])
-    assertTypeDetails(t, result, 2, ['url'], 'string', 'two', 'positional', [1], ['two'])
+  t.equal(result.argv.name, 'one')
+  t.equal(result.argv.url, 'two')
+  t.same(result.argv._, [])
+  t.same(result.details.args, ['one', 'two'])
+  t.equal(result.details.types.length, 3)
 
-    return api.parse('one')
-  }).then(result => {
-    assertNoErrors(t, result)
+  assertTypeDetails(t, result, 0, ['_'], 'array:string', [], 'default', [], [])
+  assertTypeDetails(t, result, 1, ['name'], 'string', 'one', 'positional', [0], ['one'])
+  assertTypeDetails(t, result, 2, ['url'], 'string', 'two', 'positional', [1], ['two'])
 
-    t.equal(result.argv.name, 'one')
-    t.equal(result.argv.url, undefined)
-    t.same(result.argv._, [])
+  result = await api.parse('one')
+  assertNoErrors(t, result)
 
-    return api.parse('')
-  }).then(result => {
-    t.equal(result.code, 1)
-    t.match(result.output, /Missing required argument: name/)
-    t.equal(result.errors.length, 0)
-  })
+  t.equal(result.argv.name, 'one')
+  t.equal(result.argv.url, undefined)
+  t.same(result.argv._, [])
+
+  result = await api.parse('')
+  t.equal(result.code, 1)
+  t.match(result.output, /Missing required argument: name/)
+  t.equal(result.errors.length, 0)
 })
 
-tap.test('positional > required and optional in different positions', t => {
+tap.test('positional > required and optional in different positions', async t => {
   const api = Api.get().positional('[opt1] <req1> [opt2] <req2>')
-  const promises = []
 
-  promises.push(api.parse('one two three four').then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.opt1, 'one')
-    t.equal(result.argv.req1, 'two')
-    t.equal(result.argv.opt2, 'three')
-    t.equal(result.argv.req2, 'four')
-  }))
+  const [result1, result2, result3] = await Promise.all([
+    api.parse('one two three four'),
+    api.parse('one two three'),
+    api.parse('one two')
+  ])
 
-  promises.push(api.parse('one two three').then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.opt1, 'one')
-    t.equal(result.argv.req1, 'two')
-    t.equal(result.argv.opt2, undefined)
-    t.equal(result.argv.req2, 'three')
-  }))
+  assertNoErrors(t, result1)
+  t.equal(result1.argv.opt1, 'one')
+  t.equal(result1.argv.req1, 'two')
+  t.equal(result1.argv.opt2, 'three')
+  t.equal(result1.argv.req2, 'four')
 
-  promises.push(api.parse('one two').then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.opt1, undefined)
-    t.equal(result.argv.req1, 'one')
-    t.equal(result.argv.opt2, undefined)
-    t.equal(result.argv.req2, 'two')
-  }))
+  assertNoErrors(t, result2)
+  t.equal(result2.argv.opt1, 'one')
+  t.equal(result2.argv.req1, 'two')
+  t.equal(result2.argv.opt2, undefined)
+  t.equal(result2.argv.req2, 'three')
 
-  return Promise.all(promises)
+  assertNoErrors(t, result3)
+  t.equal(result3.argv.opt1, undefined)
+  t.equal(result3.argv.req1, 'one')
+  t.equal(result3.argv.opt2, undefined)
+  t.equal(result3.argv.req2, 'two')
 })
 
-tap.test('positional > dsl for aliases', t => {
-  const promises = []
-  promises.push(Api.get().positional('"< name | email >"').parse('hi').then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.name, 'hi')
-    t.equal(result.argv.email, 'hi')
-    t.equal(Object.keys(result.argv).length, 3)
-  }))
-  promises.push(Api.get().positional('"<name | email>"').parse('hi').then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.name, 'hi')
-    t.equal(result.argv.email, 'hi')
-    t.equal(Object.keys(result.argv).length, 3)
-  }))
-  promises.push(Api.get().positional('<name|email>').parse('hi').then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.name, 'hi')
-    t.equal(result.argv.email, 'hi')
-    t.equal(Object.keys(result.argv).length, 3)
-  }))
-  return Promise.all(promises)
+tap.test('positional > dsl for aliases', async t => {
+  const [result1, result2, result3] = await Promise.all([
+    Api.get().positional('"< name | email >"').parse('hi'),
+    Api.get().positional('"<name | email>"').parse('hi'),
+    Api.get().positional('<name|email>').parse('hi')
+  ])
+
+  assertNoErrors(t, result1)
+  t.equal(result1.argv.name, 'hi')
+  t.equal(result1.argv.email, 'hi')
+  t.equal(Object.keys(result1.argv).length, 3)
+
+  assertNoErrors(t, result2)
+  t.equal(result2.argv.name, 'hi')
+  t.equal(result2.argv.email, 'hi')
+  t.equal(Object.keys(result2.argv).length, 3)
+
+  assertNoErrors(t, result3)
+  t.equal(result3.argv.name, 'hi')
+  t.equal(result3.argv.email, 'hi')
+  t.equal(Object.keys(result3.argv).length, 3)
 })
 
 tap.test('positional > dsl for flags', t => {
   const funcs = []
 
-  funcs.push(() => {
+  funcs.push(async () => {
     const api = Api.get().positional('[--name] <name> [url]')
-    return api.parse('nom earl').then(result => {
-      assertNoErrors(t, result)
-      t.equal(result.argv.name, 'nom')
-      t.equal(result.argv.url, 'earl')
-      t.equal(Object.keys(result.argv).length, 3)
-      return api.parse('earl --name nom')
-    }).then(result => {
-      assertNoErrors(t, result)
-      t.equal(result.argv.name, 'nom')
-      t.equal(result.argv.url, 'earl')
-      t.equal(Object.keys(result.argv).length, 3)
-      return api.parse('--name nom earl')
-    }).then(result => {
-      t.equal(result.argv.name, 'nom')
-      t.equal(result.argv.url, 'earl')
-      t.equal(Object.keys(result.argv).length, 3)
-    })
+
+    let result = await api.parse('nom earl')
+    assertNoErrors(t, result)
+    t.equal(result.argv.name, 'nom')
+    t.equal(result.argv.url, 'earl')
+    t.equal(Object.keys(result.argv).length, 3)
+
+    result = await api.parse('earl --name nom')
+    assertNoErrors(t, result)
+    t.equal(result.argv.name, 'nom')
+    t.equal(result.argv.url, 'earl')
+    t.equal(Object.keys(result.argv).length, 3)
+
+    result = await api.parse('--name nom earl')
+    t.equal(result.argv.name, 'nom')
+    t.equal(result.argv.url, 'earl')
+    t.equal(Object.keys(result.argv).length, 3)
   })
 
-  funcs.push(() => {
+  funcs.push(async () => {
     const api = Api.get().positional('[-n|-e] <name|email> [-u] [url]')
-    return api.parse('nom earl').then(result => {
-      assertNoErrors(t, result)
-      t.equal(result.argv.n, 'nom')
-      t.equal(result.argv.name, 'nom')
-      t.equal(result.argv.e, 'nom')
-      t.equal(result.argv.email, 'nom')
-      t.equal(result.argv.u, 'earl')
-      t.equal(result.argv.url, 'earl')
-      t.equal(Object.keys(result.argv).length, 7)
-      return api.parse('-u earl -n nom')
-    }).then(result => {
-      assertNoErrors(t, result)
-      t.equal(result.argv.n, 'nom')
-      t.equal(result.argv.name, 'nom')
-      t.equal(result.argv.e, 'nom')
-      t.equal(result.argv.email, 'nom')
-      t.equal(result.argv.u, 'earl')
-      t.equal(result.argv.url, 'earl')
-      t.equal(Object.keys(result.argv).length, 7)
-      return api.parse('-u earl skimail')
-    }).then(result => {
-      assertNoErrors(t, result)
-      t.equal(result.argv.n, 'skimail')
-      t.equal(result.argv.name, 'skimail')
-      t.equal(result.argv.e, 'skimail')
-      t.equal(result.argv.email, 'skimail')
-      t.equal(result.argv.u, 'earl')
-      t.equal(result.argv.url, 'earl')
-      t.equal(Object.keys(result.argv).length, 7)
-      return api.parse('-u earl')
-    }).then(result => {
-      t.equal(result.code, 1)
-      t.match(result.output, /Missing required argument: n or e or name or email/)
-      t.equal(result.errors.length, 0)
-    })
+
+    let result = await api.parse('nom earl')
+    assertNoErrors(t, result)
+    t.equal(result.argv.n, 'nom')
+    t.equal(result.argv.name, 'nom')
+    t.equal(result.argv.e, 'nom')
+    t.equal(result.argv.email, 'nom')
+    t.equal(result.argv.u, 'earl')
+    t.equal(result.argv.url, 'earl')
+    t.equal(Object.keys(result.argv).length, 7)
+
+    result = await api.parse('-u earl -n nom')
+    assertNoErrors(t, result)
+    t.equal(result.argv.n, 'nom')
+    t.equal(result.argv.name, 'nom')
+    t.equal(result.argv.e, 'nom')
+    t.equal(result.argv.email, 'nom')
+    t.equal(result.argv.u, 'earl')
+    t.equal(result.argv.url, 'earl')
+    t.equal(Object.keys(result.argv).length, 7)
+
+    result = await api.parse('-u earl skimail')
+    assertNoErrors(t, result)
+    t.equal(result.argv.n, 'skimail')
+    t.equal(result.argv.name, 'skimail')
+    t.equal(result.argv.e, 'skimail')
+    t.equal(result.argv.email, 'skimail')
+    t.equal(result.argv.u, 'earl')
+    t.equal(result.argv.url, 'earl')
+    t.equal(Object.keys(result.argv).length, 7)
+
+    result = await api.parse('-u earl')
+    t.equal(result.code, 1)
+    t.match(result.output, /Missing required argument: n or e or name or email/)
+    t.equal(result.errors.length, 0)
   })
 
   return Promise.all(funcs.map(p => p()))
 })
 
-tap.test('positional > dsl for type', t => {
-  const promises = []
-  promises.push(Api.get().positional('<array>').parse('a b').then(result => {
-    assertNoErrors(t, result)
-    t.same(result.argv.array, ['a', 'b'])
-    t.equal(Object.keys(result.argv).length, 2)
-    assertTypeDetails(t, result, 1, ['array'], 'array:string', ['a', 'b'], 'positional', [0, 1], ['a', 'b'])
-  }))
-  promises.push(Api.get().positional('<sum:array:number>').parse('1 2 3').then(result => {
-    assertNoErrors(t, result)
-    t.same(result.argv.sum, [1, 2, 3])
-    t.equal(Object.keys(result.argv).length, 2)
-    assertTypeDetails(t, result, 1, ['sum'], 'array:number', [1, 2, 3], 'positional', [0, 1, 2], ['1', '2', '3'])
-  }))
-  promises.push(Api.get().positional('[port:number]').parse('80').then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.port, 80)
-    t.equal(Object.keys(result.argv).length, 2)
-    assertTypeDetails(t, result, 1, ['port'], 'number', 80, 'positional', [0], ['80'])
-  }))
-  promises.push(Api.get().positional('<path>').parse('/home').then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.path, '/home')
-    t.equal(Object.keys(result.argv).length, 2)
-    assertTypeDetails(t, result, 1, ['path'], 'path', '/home', 'positional', [0], ['/home'])
-  }))
-  promises.push(Api.get().positional('<path:file>').parse('package.json').then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.path, 'package.json')
-    t.equal(Object.keys(result.argv).length, 2)
-    assertTypeDetails(t, result, 1, ['path'], 'file', 'package.json', 'positional', [0], ['package.json'])
-  }))
-  promises.push(Api.get().positional('<choice:enum>', { params: [{ choices: ['y', 'n'] }] }).parse('y').then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.choice, 'y')
-    t.equal(Object.keys(result.argv).length, 2)
-    assertTypeDetails(t, result, 1, ['choice'], 'enum', 'y', 'positional', [0], ['y'])
-  }))
-  return Promise.all(promises)
+tap.test('positional > dsl for type', async t => {
+  const [result1, result2, result3, result4, result5, result6] = await Promise.all([
+    Api.get().positional('<array>').parse('a b'),
+    Api.get().positional('<sum:array:number>').parse('1 2 3'),
+    Api.get().positional('[port:number]').parse('80'),
+    Api.get().positional('<path>').parse('/home'),
+    Api.get().positional('<path:file>').parse('package.json'),
+    Api.get().positional('<choice:enum>', { params: [{ choices: ['y', 'n'] }] }).parse('y')
+  ])
+
+  assertNoErrors(t, result1)
+  t.same(result1.argv.array, ['a', 'b'])
+  t.equal(Object.keys(result1.argv).length, 2)
+  assertTypeDetails(t, result1, 1, ['array'], 'array:string', ['a', 'b'], 'positional', [0, 1], ['a', 'b'])
+
+  assertNoErrors(t, result2)
+  t.same(result2.argv.sum, [1, 2, 3])
+  t.equal(Object.keys(result2.argv).length, 2)
+  assertTypeDetails(t, result2, 1, ['sum'], 'array:number', [1, 2, 3], 'positional', [0, 1, 2], ['1', '2', '3'])
+
+  assertNoErrors(t, result3)
+  t.equal(result3.argv.port, 80)
+  t.equal(Object.keys(result3.argv).length, 2)
+  assertTypeDetails(t, result3, 1, ['port'], 'number', 80, 'positional', [0], ['80'])
+
+  assertNoErrors(t, result4)
+  t.equal(result4.argv.path, '/home')
+  t.equal(Object.keys(result4.argv).length, 2)
+  assertTypeDetails(t, result4, 1, ['path'], 'path', '/home', 'positional', [0], ['/home'])
+
+  assertNoErrors(t, result5)
+  t.equal(result5.argv.path, 'package.json')
+  t.equal(Object.keys(result5.argv).length, 2)
+  assertTypeDetails(t, result5, 1, ['path'], 'file', 'package.json', 'positional', [0], ['package.json'])
+
+  assertNoErrors(t, result6)
+  t.equal(result6.argv.choice, 'y')
+  t.equal(Object.keys(result6.argv).length, 2)
+  assertTypeDetails(t, result6, 1, ['choice'], 'enum', 'y', 'positional', [0], ['y'])
 })
 
-tap.test('positional > dsl supports custom type/factory', t => {
+tap.test('positional > dsl supports custom type/factory', async t => {
   class Mod extends TypeString { get datatype () { return 'custom' } }
-  return Api.get().registerFactory('mod', opts => new Mod(opts)).positional('thing:mod').parse('test').then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.thing, 'test')
-    t.equal(Object.keys(result.argv).length, 2)
-    assertTypeDetails(t, result, 1, ['thing'], 'custom', 'test', 'positional', [0], ['test'])
-  })
+  const result = await Api.get().registerFactory('mod', opts => new Mod(opts)).positional('thing:mod').parse('test')
+  assertNoErrors(t, result)
+  t.equal(result.argv.thing, 'test')
+  t.equal(Object.keys(result.argv).length, 2)
+  assertTypeDetails(t, result, 1, ['thing'], 'custom', 'test', 'positional', [0], ['test'])
 })
 
-tap.test('positional > dsl for variadics', t => {
-  const promises = []
+tap.test('positional > dsl for variadics', async t => {
+  const [result1, result2, result3] = await Promise.all([
+    Api.get().positional('<a> <b> <c..>').parse('one two three four'),
+    Api.get().positional('<a> <b..> <c>').parse('one two three four'),
+    Api.get().positional('<a..> <b..> <c>').parse('one two three four')
+  ])
 
-  promises.push(Api.get().positional('<a> <b> <c..>').parse('one two three four').then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.a, 'one')
-    t.equal(result.argv.b, 'two')
-    t.same(result.argv.c, ['three', 'four'])
-    assertTypeDetails(t, result, 1, ['a'], 'string', 'one', 'positional', [0], ['one'])
-    assertTypeDetails(t, result, 2, ['b'], 'string', 'two', 'positional', [1], ['two'])
-    assertTypeDetails(t, result, 3, ['c'], 'array:string', ['three', 'four'], 'positional', [2, 3], ['three', 'four'])
-  }))
+  assertNoErrors(t, result1)
+  t.equal(result1.argv.a, 'one')
+  t.equal(result1.argv.b, 'two')
+  t.same(result1.argv.c, ['three', 'four'])
+  assertTypeDetails(t, result1, 1, ['a'], 'string', 'one', 'positional', [0], ['one'])
+  assertTypeDetails(t, result1, 2, ['b'], 'string', 'two', 'positional', [1], ['two'])
+  assertTypeDetails(t, result1, 3, ['c'], 'array:string', ['three', 'four'], 'positional', [2, 3], ['three', 'four'])
 
-  promises.push(Api.get().positional('<a> <b..> <c>').parse('one two three four').then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.a, 'one')
-    t.same(result.argv.b, ['two', 'three'])
-    t.equal(result.argv.c, 'four')
-    assertTypeDetails(t, result, 1, ['a'], 'string', 'one', 'positional', [0], ['one'])
-    assertTypeDetails(t, result, 2, ['b'], 'array:string', ['two', 'three'], 'positional', [1, 2], ['two', 'three'])
-    assertTypeDetails(t, result, 3, ['c'], 'string', 'four', 'positional', [3], ['four'])
-  }))
+  assertNoErrors(t, result2)
+  t.equal(result2.argv.a, 'one')
+  t.same(result2.argv.b, ['two', 'three'])
+  t.equal(result2.argv.c, 'four')
+  assertTypeDetails(t, result2, 1, ['a'], 'string', 'one', 'positional', [0], ['one'])
+  assertTypeDetails(t, result2, 2, ['b'], 'array:string', ['two', 'three'], 'positional', [1, 2], ['two', 'three'])
+  assertTypeDetails(t, result2, 3, ['c'], 'string', 'four', 'positional', [3], ['four'])
 
-  promises.push(Api.get().positional('<a..> <b..> <c>').parse('one two three four').then(result => {
-    assertNoErrors(t, result)
-    t.same(result.argv.a, ['one', 'two'])
-    t.same(result.argv.b, ['three'])
-    t.equal(result.argv.c, 'four')
-    assertTypeDetails(t, result, 1, ['a'], 'array:string', ['one', 'two'], 'positional', [0, 1], ['one', 'two'])
-    assertTypeDetails(t, result, 2, ['b'], 'array:string', ['three'], 'positional', [2], ['three'])
-    assertTypeDetails(t, result, 3, ['c'], 'string', 'four', 'positional', [3], ['four'])
-  }))
-
-  return Promise.all(promises)
+  assertNoErrors(t, result3)
+  t.same(result3.argv.a, ['one', 'two'])
+  t.same(result3.argv.b, ['three'])
+  t.equal(result3.argv.c, 'four')
+  assertTypeDetails(t, result3, 1, ['a'], 'array:string', ['one', 'two'], 'positional', [0, 1], ['one', 'two'])
+  assertTypeDetails(t, result3, 2, ['b'], 'array:string', ['three'], 'positional', [2], ['three'])
+  assertTypeDetails(t, result3, 3, ['c'], 'string', 'four', 'positional', [3], ['four'])
 })
 
-tap.test('positional > dsl for default value', t => {
+tap.test('positional > dsl for default value', async t => {
   const api = Api.get().positional('[file=package.json] [port:number=8080] [svcs..=one,two]')
-  return api.parse('').then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.file, 'package.json')
-    t.equal(result.argv.port, 8080)
-    t.same(result.argv.svcs, ['one', 'two'])
-    assertTypeDetails(t, result, 1, ['file'], 'file', 'package.json', 'default', [], [])
-    assertTypeDetails(t, result, 2, ['port'], 'number', 8080, 'default', [], [])
-    assertTypeDetails(t, result, 3, ['svcs'], 'array:string', ['one', 'two'], 'default', [], [])
-    return api.parse('config.json 4000 all')
-  }).then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.file, 'config.json')
-    t.equal(result.argv.port, 4000)
-    t.same(result.argv.svcs, ['all'])
-    assertTypeDetails(t, result, 1, ['file'], 'file', 'config.json', 'positional', [0], ['config.json'])
-    assertTypeDetails(t, result, 2, ['port'], 'number', 4000, 'positional', [1], ['4000'])
-    assertTypeDetails(t, result, 3, ['svcs'], 'array:string', ['all'], 'positional', [2], ['all'])
-  })
+
+  let result = await api.parse('')
+  assertNoErrors(t, result)
+  t.equal(result.argv.file, 'package.json')
+  t.equal(result.argv.port, 8080)
+  t.same(result.argv.svcs, ['one', 'two'])
+  assertTypeDetails(t, result, 1, ['file'], 'file', 'package.json', 'default', [], [])
+  assertTypeDetails(t, result, 2, ['port'], 'number', 8080, 'default', [], [])
+  assertTypeDetails(t, result, 3, ['svcs'], 'array:string', ['one', 'two'], 'default', [], [])
+
+  result = await api.parse('config.json 4000 all')
+  assertNoErrors(t, result)
+  t.equal(result.argv.file, 'config.json')
+  t.equal(result.argv.port, 4000)
+  t.same(result.argv.svcs, ['all'])
+  assertTypeDetails(t, result, 1, ['file'], 'file', 'config.json', 'positional', [0], ['config.json'])
+  assertTypeDetails(t, result, 2, ['port'], 'number', 4000, 'positional', [1], ['4000'])
+  assertTypeDetails(t, result, 3, ['svcs'], 'array:string', ['all'], 'positional', [2], ['all'])
 })
 
 tap.test('positional > params as array 1/2', t => {
@@ -451,28 +441,26 @@ tap.test('positional > paramsGroup', t => {
   t.end()
 })
 
-tap.test('positional > ignore', t => {
+tap.test('positional > ignore', async t => {
   const opts = { ignore: '[options]' }
-  return Api.get()
+  const result = await Api.get()
     .positional('<one> [options]', opts)
-    .parse('uno dos').then(result => {
-      assertNoErrors(t, result)
-      t.equal(result.argv.one, 'uno')
-      t.same(result.argv._, ['dos'])
-      t.equal(Object.keys(result.argv).length, 2)
-      assertTypeDetails(t, result, 0, ['_'], 'array:string', ['dos'], 'positional', [1], ['dos'])
-      assertTypeDetails(t, result, 1, ['one'], 'string', 'uno', 'positional', [0], ['uno'])
-      // assert that the call to positional() didn't modify the objects given
-      t.equal(Object.keys(opts).length, 1)
-      t.equal(opts.ignore, '[options]')
-    })
+    .parse('uno dos')
+  assertNoErrors(t, result)
+  t.equal(result.argv.one, 'uno')
+  t.same(result.argv._, ['dos'])
+  t.equal(Object.keys(result.argv).length, 2)
+  assertTypeDetails(t, result, 0, ['_'], 'array:string', ['dos'], 'positional', [1], ['dos'])
+  assertTypeDetails(t, result, 1, ['one'], 'string', 'uno', 'positional', [0], ['uno'])
+  // assert that the call to positional() didn't modify the objects given
+  t.equal(Object.keys(opts).length, 1)
+  t.equal(opts.ignore, '[options]')
 })
 
-tap.test('positional > coerce', t => {
-  return Api.get().positional('<one>', {
+tap.test('positional > coerce', async t => {
+  const result = await Api.get().positional('<one>', {
     params: [{ coerce: val => val && val.split('..') }]
-  }).parse('x..y').then(result => {
-    assertNoErrors(t, result)
-    t.same(result.argv.one, ['x', 'y'])
-  })
+  }).parse('x..y')
+  assertNoErrors(t, result)
+  t.same(result.argv.one, ['x', 'y'])
 })

--- a/test/types/test-version.js
+++ b/test/types/test-version.js
@@ -43,16 +43,15 @@ tap.beforeEach(() => {
   })
 })
 
-tap.afterEach(() => {
+tap.afterEach(async () => {
   if (!shouldDeleteFile) return Promise.resolve()
   // console.error('########## DELETING CUSTOM PACKAGE.JSON FILE')
-  return del('package.json').then(whenDone => {
-    shouldDeleteFile = false
-    expectedVersion = undefined
-  })
+  await del('package.json')
+  shouldDeleteFile = false
+  expectedVersion = undefined
 })
 
-tap.test('version > defaults', t => {
+tap.test('version > defaults', async t => {
   const api = Api.get().version()
   const typeObjects = api.initContext(true).types
   t.same(typeObjects[parent][0].aliases, ['version'])
@@ -62,13 +61,12 @@ tap.test('version > defaults', t => {
   t.equal(typeObjects[parent][0].helpHints, '[commands: version] [boolean]')
   t.equal(typeObjects[parent][0].helpGroup, 'Options:')
   t.equal(typeObjects[parent][0].isHidden, false)
-  return api.parse('--version').then(result => {
-    t.equal(result.code, 0)
-    t.equal(result.output, expectedVersion || versionFixture)
-    t.equal(result.errors.length, 0)
-    t.equal(result.argv.version, true)
-    assertTypeDetails(t, result, 1, ['version'], 'boolean', true, 'flag', [0], ['--version'])
-  })
+  const result = await api.parse('--version')
+  t.equal(result.code, 0)
+  t.equal(result.output, expectedVersion || versionFixture)
+  t.equal(result.errors.length, 0)
+  t.equal(result.argv.version, true)
+  assertTypeDetails(t, result, 1, ['version'], 'boolean', true, 'flag', [0], ['--version'])
 })
 
 tap.test('version > custom flags, desc, group, hints', t => {
@@ -87,76 +85,73 @@ tap.test('version > custom flags, desc, group, hints', t => {
   t.end()
 })
 
-tap.test('version > default implicit command', t => {
+tap.test('version > default implicit command', async t => {
   const api = Api.get().version()
-  return api.parse('version').then(result => {
-    t.equal(result.code, 0)
-    t.equal(result.output, expectedVersion || versionFixture)
-    t.equal(result.errors.length, 0)
-    t.equal(result.argv.version, true)
-    assertTypeDetails(t, result, 1, ['version'], 'boolean', true, 'positional', [0], ['version'])
-    return api.parse('not version')
-  }).then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.version, false)
-    t.same(result.argv._, ['not', 'version'])
-    assertTypeDetails(t, result, 0, ['_'], 'array:string', ['not', 'version'], 'positional', [0, 1], ['not', 'version'])
-    assertTypeDetails(t, result, 1, ['version'], 'boolean', false, 'default', [], [])
-  })
+
+  let result = await api.parse('version')
+  t.equal(result.code, 0)
+  t.equal(result.output, expectedVersion || versionFixture)
+  t.equal(result.errors.length, 0)
+  t.equal(result.argv.version, true)
+  assertTypeDetails(t, result, 1, ['version'], 'boolean', true, 'positional', [0], ['version'])
+
+  result = await api.parse('not version')
+  assertNoErrors(t, result)
+  t.equal(result.argv.version, false)
+  t.same(result.argv._, ['not', 'version'])
+  assertTypeDetails(t, result, 0, ['_'], 'array:string', ['not', 'version'], 'positional', [0, 1], ['not', 'version'])
+  assertTypeDetails(t, result, 1, ['version'], 'boolean', false, 'default', [], [])
 })
 
-tap.test('version > custom implicit command via flags', t => {
+tap.test('version > custom implicit command via flags', async t => {
   const api = Api.get().version('-V | --get-version')
-  return api.parse('get-version').then(result => {
-    t.equal(result.code, 0)
-    t.equal(result.output, expectedVersion || versionFixture)
-    t.equal(result.errors.length, 0)
-    t.equal(result.argv.V, true)
-    t.equal(result.argv['get-version'], true)
-    assertTypeDetails(t, result, 1, ['V', 'get-version'], 'boolean', true, 'positional', [0], ['get-version'])
-    return api.parse('V')
-  }).then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.V, false)
-    t.equal(result.argv['get-version'], false)
-    t.same(result.argv._, ['V'])
-    assertTypeDetails(t, result, 0, ['_'], 'array:string', ['V'], 'positional', [0], ['V'])
-    assertTypeDetails(t, result, 1, ['V', 'get-version'], 'boolean', false, 'default', [], [])
-  })
+
+  let result = await api.parse('get-version')
+  t.equal(result.code, 0)
+  t.equal(result.output, expectedVersion || versionFixture)
+  t.equal(result.errors.length, 0)
+  t.equal(result.argv.V, true)
+  t.equal(result.argv['get-version'], true)
+  assertTypeDetails(t, result, 1, ['V', 'get-version'], 'boolean', true, 'positional', [0], ['get-version'])
+
+  result = await api.parse('V')
+  assertNoErrors(t, result)
+  t.equal(result.argv.V, false)
+  t.equal(result.argv['get-version'], false)
+  t.same(result.argv._, ['V'])
+  assertTypeDetails(t, result, 0, ['_'], 'array:string', ['V'], 'positional', [0], ['V'])
+  assertTypeDetails(t, result, 1, ['V', 'get-version'], 'boolean', false, 'default', [], [])
 })
 
-tap.test('version > disable implicit command', t => {
-  return Api.get().version({ implicitCommand: false }).parse('version').then(result => {
-    assertNoErrors(t, result)
-    t.equal(result.argv.version, false)
-    t.same(result.argv._, ['version'])
-    assertTypeDetails(t, result, 0, ['_'], 'array:string', ['version'], 'positional', [0], ['version'])
-    assertTypeDetails(t, result, 1, ['version'], 'boolean', false, 'default', [], [])
-  })
+tap.test('version > disable implicit command', async t => {
+  const result = await Api.get().version({ implicitCommand: false }).parse('version')
+  assertNoErrors(t, result)
+  t.equal(result.argv.version, false)
+  t.same(result.argv._, ['version'])
+  assertTypeDetails(t, result, 0, ['_'], 'array:string', ['version'], 'positional', [0], ['version'])
+  assertTypeDetails(t, result, 1, ['version'], 'boolean', false, 'default', [], [])
 })
 
-tap.test('version > custom version string', t => {
-  return Api.get().version('-v, --version', {
+tap.test('version > custom version string', async t => {
+  const result = await Api.get().version('-v, --version', {
     version: '3.14159265359'
-  }).parse('-v').then(result => {
-    t.equal(result.code, 0)
-    t.equal(result.output, '3.14159265359')
-    t.equal(result.errors.length, 0)
-    t.equal(result.argv.v, true)
-    t.equal(result.argv.version, true)
-    assertTypeDetails(t, result, 1, ['v', 'version'], 'boolean', true, 'flag', [0], ['-v'])
-  })
+  }).parse('-v')
+  t.equal(result.code, 0)
+  t.equal(result.output, '3.14159265359')
+  t.equal(result.errors.length, 0)
+  t.equal(result.argv.v, true)
+  t.equal(result.argv.version, true)
+  assertTypeDetails(t, result, 1, ['v', 'version'], 'boolean', true, 'flag', [0], ['-v'])
 })
 
-tap.test('version > custom version function', t => {
-  return Api.get().version('-v, --version', {
+tap.test('version > custom version function', async t => {
+  const result = await Api.get().version('-v, --version', {
     version: () => '6.2831853071' // currently must be synchronous
-  }).parse('-v').then(result => {
-    t.equal(result.code, 0)
-    t.equal(result.output, '6.2831853071')
-    t.equal(result.errors.length, 0)
-    t.equal(result.argv.v, true)
-    t.equal(result.argv.version, true)
-    assertTypeDetails(t, result, 1, ['v', 'version'], 'boolean', true, 'flag', [0], ['-v'])
-  })
+  }).parse('-v')
+  t.equal(result.code, 0)
+  t.equal(result.output, '6.2831853071')
+  t.equal(result.errors.length, 0)
+  t.equal(result.argv.v, true)
+  t.equal(result.argv.version, true)
+  assertTypeDetails(t, result, 1, ['v', 'version'], 'boolean', true, 'flag', [0], ['-v'])
 })

--- a/types/array.js
+++ b/types/array.js
@@ -106,10 +106,9 @@ class TypeArray extends TypeWrapper {
     return super.isStrict || this.elementType.isStrict
   }
 
-  validateValue (value, context) {
-    return Promise.all((value || []).map(v => this.elementType.validateValue(v, context))).then(validArray => {
-      return (validArray || []).filter(isValid => !isValid).length === 0
-    })
+  async validateValue (value, context) {
+    const validArray = await Promise.all((value || []).map(v => this.elementType.validateValue(v, context)))
+    return (validArray || []).filter(isValid => !isValid).length === 0
   }
 
   buildInvalidMessage (context, msgAndArgs) {

--- a/types/command.js
+++ b/types/command.js
@@ -86,7 +86,7 @@ class TypeCommand extends Type {
     return super.resolve()
   }
 
-  postParse (context) {
+  async postParse (context) {
     const match = context.matchCommand(this.api.parentName, this.validAliases, this.isDefault)
     if (!match.explicit && !match.implicit) return this.resolve()
 
@@ -118,18 +118,18 @@ class TypeCommand extends Type {
       this.setupHandler(this.api)
     }
 
-    return this.api.parseFromContext(context).then(whenDone => {
-      // only run innermost command handler
-      if (context.commandHandlerRun) return this.resolve()
-      context.commandHandlerRun = true
-      this.api.addStrictModeErrors(context)
-      if (context.helpRequested || context.messages.length) {
-        // console.log('command.js postParse > adding deferred help, implicit:', match.implicit)
-        if (!context.output) context.addDeferredHelp(this.api.initHelpBuffer())
-        return this.resolve()
-      }
-      return this.runHandler(context.argv, context)
-    })
+    await this.api.parseFromContext(context)
+
+    // only run innermost command handler
+    if (context.commandHandlerRun) return this.resolve()
+    context.commandHandlerRun = true
+    this.api.addStrictModeErrors(context)
+    if (context.helpRequested || context.messages.length) {
+      // console.log('command.js postParse > adding deferred help, implicit:', match.implicit)
+      if (!context.output) context.addDeferredHelp(this.api.initHelpBuffer())
+      return this.resolve()
+    }
+    return this.runHandler(context.argv, context)
   }
 }
 

--- a/types/positional.js
+++ b/types/positional.js
@@ -47,19 +47,21 @@ class TypePositional extends TypeWrapper {
   }
 
   // called by api
-  parse (context) {
+  async parse (context) {
     // only need to parse for flags
     // otherwise will be populated by unknownType
     if (this.acceptFlags) {
       // first pass of parsing checks for flags with validation disabled
-      return this.elementType._internalParse(context, false).then(whenDone => this.resolve())
+      await this.elementType._internalParse(context, false)
+      return this.resolve()
     }
     return super.resolve()
   }
 
   // called by unknownType
-  validateParsed (context) {
-    return this.elementType.validateParsed(context).then(whenDone => super.resolve())
+  async validateParsed (context) {
+    await this.elementType.validateParsed(context)
+    return super.resolve()
   }
 
   // called by unknownType

--- a/types/unknown.js
+++ b/types/unknown.js
@@ -30,7 +30,7 @@ class TypeUnknown extends Type {
     })
   }
 
-  parse (context) {
+  async parse (context) {
     // console.log('parse', this.constructor.name)
     // find all slurped args that have unclaimed kv pairs
     const unknownSlurped = []
@@ -95,7 +95,7 @@ class TypeUnknown extends Type {
     if (v.length > 0) this.applySource(context, Type.SOURCE_POSITIONAL)
 
     if (this.positionals && this.positionals.length) {
-      return Promise.all(this.positionals.map(p => p.validateParsed(context))).then(whenDone => super.resolve())
+      await Promise.all(this.positionals.map(p => p.validateParsed(context)))
     }
 
     return super.resolve()


### PR DESCRIPTION
No functional/behavioral changes are intended, just reduces the code footprint slightly and makes things easier to read and maintain going forward.

**BREAKING CHANGE** This drops compatibility with Node versions below 8.