### PR TITLE
CLI messages added by run handlers should show contextual help

### DIFF
--- a/test/types/test-command.js
+++ b/test/types/test-command.js
@@ -553,7 +553,11 @@ tap.test('command > run handler > adding cli message affects result', async t =>
     })
     .parse('fail')
   t.equal(result.code, 1)
-  t.match(result.output, /You broke it/)
+  t.equal(result.output, [
+    'Usage: test-command fail',
+    '',
+    'You broke it'
+  ].join('\n'))
   t.equal(result.errors.length, 0)
 })
 

--- a/types/command.js
+++ b/types/command.js
@@ -132,13 +132,11 @@ class TypeCommand extends Type {
     if (context.commandHandlerRun) return this.resolve()
     context.commandHandlerRun = true
     this.api.addStrictModeErrors(context)
-    if (this._initPossibleHelpBuffer(context)) {
-      return this.resolve()
-    }
-    return Promise.resolve(this.runHandler(context.argv, context)).then(result => {
-      this._initPossibleHelpBuffer(context)
-      return result
-    })
+    if (this._initPossibleHelpBuffer(context)) return this.resolve()
+
+    const result = await this.runHandler(context.argv, context)
+    this._initPossibleHelpBuffer(context)
+    return result
   }
 }
 


### PR DESCRIPTION
### SUMMARY

Fixes #49 - a CLI message added to context during a command's run handler (instead of setup or parse) ends up displaying help from the wrong level.

### TESTS

Minor adjustment to an existing test to make it more strict.
