### PR TITLE
Allow developer to customize how errors are formatted

### DIFF
--- a/api.js
+++ b/api.js
@@ -82,7 +82,7 @@ class Api {
       'lineSep', 'sectionSep', 'pad', 'indent', 'split', 'icon', 'slogan',
       'usagePrefix', 'usageHasOptions', 'groupOrder', 'epilogue', 'maxWidth',
       'examplePrefix', 'exampleOrder', 'usageCommandPlaceholder',
-      'usageArgsPlaceholder', 'usageOptionsPlaceholder', 'showHelpOnError',
+      'usageArgsPlaceholder', 'usageOptionsPlaceholder', 'showHelpOnError', 'errorFormat',
       'styleGroup', 'styleGroupError', 'styleFlags', 'styleFlagsError',
       'styleDesc', 'styleDescError', 'styleHints', 'styleHintsError', 'styleMessages',
       'styleUsagePrefix', 'styleUsagePositionals', 'styleUsageCommandPlaceholder',
@@ -255,6 +255,11 @@ class Api {
 
   epilogue (epilogue) {
     this.helpOpts.epilogue = epilogue
+    return this
+  }
+
+  errorFormat(fn) {
+    this.helpOpts.errorFormat = fn
     return this
   }
 
@@ -630,7 +635,7 @@ class Api {
         context.addDeferredHelp(this.initHelpBuffer())
       }
     } catch (err) {
-      context.unexpectedError(err)
+      context.unexpectedError(err, this.helpOpts.errorFormat ? this.helpOpts.errorFormat(err) : undefined)
     }
 
     return context.toResult()

--- a/context.js
+++ b/context.js
@@ -140,9 +140,9 @@ class Context {
     return this
   }
 
-  unexpectedError (err) {
+  unexpectedError (err, formatted) {
     this.errors.push(err)
-    this.output = String((err && err.stack) || err)
+    this.output = formatted || String((err && err.stack) || err)
     this.code++
   }
 


### PR DESCRIPTION
### SUMMARY

Allow the developer to customize how "unexpected errors" (errors thrown during execution of a command or during validation) are displayed by sywac.

### DETAILS

This is one of many possible interfaces (another way would be to embed it in `outputSettings`).  But chaining it like this feels more natural to me.

```js
require('sywac')
  .command('start', /* ... */)
  .command('stop', /* ... */)
  .errorFormat(error => error instanceof AWS.Error ? error.message : error.stack)
  .parseAndExit()
```

This example would display most errors as the normal stack trace, but displays any errors extending from `AWS.Error` as just the message.

### NEXT STEPS

If this approach seems intuitive enough I can add some unit tests.
