### PR TITLE
Allow passing an optional user context to parse and parseAndExit

### DIFF
--- a/api.js
+++ b/api.js
@@ -710,7 +710,7 @@ class Api {
       utils: this.utils,
       pathLib: this.pathLib,
       fsLib: this.fsLib,
-      state: state
+      state
     })
     return includeTypes ? this.applyTypes(context) : context
   }

--- a/api.js
+++ b/api.js
@@ -591,8 +591,8 @@ class Api {
 
   // parse and exit if there's output (e.g. help text) or a non-zero code; otherwise resolves to argv
   // useful for standard CLIs
-  async parseAndExit (args) {
-    const context = await this._parse(args)
+  async parseAndExit (args, userContext) {
+    const context = await this._parse(args, userContext)
     const result = context.toResult()
     if (result.output) {
       // note that we want context.helpRequestedImplicitly to output to stderr, not stdout
@@ -606,14 +606,17 @@ class Api {
 
   // parse and resolve to a context result (never exits)
   // useful for chatbots or checking results
-  async parse (args) {
-    const context = await this._parse(args)
+  async parse (args, userContext) {
+    const context = await this._parse(args, userContext)
     return context.toResult()
   }
 
-  async _parse (args) {
+  async _parse (args, userContext) {
     // init context and kick off recursive type parsing/execution
     const context = this.initContext(false).slurpArgs(args)
+    if (typeof userContext !== "undefined") {
+      context.argv.$ = userContext
+    }
 
     // init unknownType in context only for the top-level (all levels share/overwrite the same argv._)
     if (this.unknownType) {
@@ -709,7 +712,7 @@ class Api {
     const context = this.get('_context', {
       utils: this.utils,
       pathLib: this.pathLib,
-      fsLib: this.fsLib
+      fsLib: this.fsLib,
     })
     return includeTypes ? this.applyTypes(context) : context
   }

--- a/api.js
+++ b/api.js
@@ -591,8 +591,8 @@ class Api {
 
   // parse and exit if there's output (e.g. help text) or a non-zero code; otherwise resolves to argv
   // useful for standard CLIs
-  async parseAndExit (args, userContext) {
-    const context = await this._parse(args, userContext)
+  async parseAndExit (args, state) {
+    const context = await this._parse(args, state)
     const result = context.toResult()
     if (result.output) {
       // note that we want context.helpRequestedImplicitly to output to stderr, not stdout
@@ -606,17 +606,14 @@ class Api {
 
   // parse and resolve to a context result (never exits)
   // useful for chatbots or checking results
-  async parse (args, userContext) {
-    const context = await this._parse(args, userContext)
+  async parse (args, state) {
+    const context = await this._parse(args, state)
     return context.toResult()
   }
 
-  async _parse (args, userContext) {
+  async _parse (args, state) {
     // init context and kick off recursive type parsing/execution
-    const context = this.initContext(false).slurpArgs(args)
-    if (typeof userContext !== "undefined") {
-      context.argv.$ = userContext
-    }
+    const context = this.initContext(false, state).slurpArgs(args)
 
     // init unknownType in context only for the top-level (all levels share/overwrite the same argv._)
     if (this.unknownType) {
@@ -708,11 +705,12 @@ class Api {
     return Promise.all(postParse)
   }
 
-  initContext (includeTypes) {
+  initContext (includeTypes, state) {
     const context = this.get('_context', {
       utils: this.utils,
       pathLib: this.pathLib,
       fsLib: this.fsLib,
+      state: state
     })
     return includeTypes ? this.applyTypes(context) : context
   }

--- a/context.js
+++ b/context.js
@@ -14,6 +14,7 @@ class Context {
     this._pathLib = opts.pathLib
     this._fsLib = opts.fsLib
     // config
+    this.state = opts.state
     this.types = {}
     // args to parse per type
     this.args = []

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -70,7 +70,6 @@ tap.test('api > help text', t => {
     'epilogue'
   ].join('\n'))
   t.same(includeExamples, true)
-
   t.end()
 })
 
@@ -103,6 +102,24 @@ tap.test('api > custom helpBuffer', t => {
     .registerFactory('helpBuffer', () => ({ toString: () => 'Complete override' }))
     .getHelp()
   t.same(helpText, 'Complete override')
+  t.end()
+})
+
+tap.test('api > help configuration functions ignore or massage invalid params', t => {
+  const helpText = Api.get()
+    .usage()
+    .groupOrder({ value: 'ignored' })
+    .example()
+    .exampleOrder({ value: 'ignored' })
+    .outputSettings()
+    .style()
+    .registerFactory()
+    .getHelp()
+  t.equal(helpText, [
+    'Usage: test-api',
+    '',
+    'Examples:'
+  ].join('\n'))
   t.end()
 })
 

--- a/test/test-parse-and-exit.js
+++ b/test/test-parse-and-exit.js
@@ -241,15 +241,16 @@ tap.test('parseAndExit > success', async t => {
   t.equal(argv.identity, '~/.ssh/id_rsa')
 })
 
-tap.test('parseAndExit > user context', async t => {
-  const api = Api.get()
-  const userContext = { name: 'jan.jansen', home: '/Users/jan' }
+tap.test('parseAndExit > state', async t => {
+  const state = { name: 'jan.jansen', home: '/Users/jan' }
+  let _context
+  const api = Api.get().check((argv, context) => { _context = context })
 
-  let argv = await api.parseAndExit('-x Hello', userContext)
+  let argv = await api.parseAndExit('-x Hello', state)
   t.equal(argv.x, 'Hello')
-  t.equal(argv.$, userContext)
+  t.equal(_context.state, state)
 
   argv = await api.parseAndExit('-x Hello')
   t.equal(argv.x, 'Hello')
-  t.equal(Object.keys(argv).indexOf('$'), -1)
+  t.equal(_context.state, undefined)
 })

--- a/test/test-parse-and-exit.js
+++ b/test/test-parse-and-exit.js
@@ -4,6 +4,7 @@ const tap = require('tap')
 const cp = require('child_process')
 const path = require('path')
 const chalk = require('chalk')
+const Api = require('../api')
 
 const topLevelHelp = [
   chalk`{white Usage:} {magenta ndb}` + ' ' + chalk.magenta('<command>') + ' ' + chalk.yellow('<args>') + ' ' + chalk.green('[options]'),
@@ -238,4 +239,17 @@ tap.test('parseAndExit > success', async t => {
   t.equal(argv.user, 'admin')
   t.equal(argv.i, '~/.ssh/id_rsa')
   t.equal(argv.identity, '~/.ssh/id_rsa')
+})
+
+tap.test('parseAndExit > user context', async t => {
+  const api = Api.get()
+  const userContext = { name: 'jan.jansen', home: '/Users/jan' }
+
+  let argv = await api.parseAndExit('-x Hello', userContext)
+  t.equal(argv.x, 'Hello')
+  t.equal(argv.$, userContext)
+
+  argv = await api.parseAndExit('-x Hello')
+  t.equal(argv.x, 'Hello')
+  t.equal(Object.keys(argv).indexOf('$'), -1)
 })

--- a/test/test-parse.js
+++ b/test/test-parse.js
@@ -410,3 +410,18 @@ tap.test('parse > custom async check', async t => {
   t.equal(called, 4)
   t.equal(result.argv.looksGood, true)
 })
+
+tap.test('parse > user context', async t => {
+  const api = Api.get()
+  const userContext = { name: 'jan.jansen', home: '/Users/jan' }
+
+  let result = await api.parse('-x Hello', userContext)
+  t.equal(result.code, 0)
+  t.equal(result.argv.x, 'Hello')
+  t.equal(result.argv.$, userContext)
+
+  result = await api.parse('-x Hello')
+  t.equal(result.code, 0)
+  t.equal(result.argv.x, 'Hello')
+  t.equal(Object.keys(result.argv).indexOf('$'), -1)
+})

--- a/test/test-parse.js
+++ b/test/test-parse.js
@@ -411,17 +411,18 @@ tap.test('parse > custom async check', async t => {
   t.equal(result.argv.looksGood, true)
 })
 
-tap.test('parse > user context', async t => {
-  const api = Api.get()
-  const userContext = { name: 'jan.jansen', home: '/Users/jan' }
+tap.test('parse > state', async t => {
+  const state = { name: 'jan.jansen', home: '/Users/jan' }
+  let _context
+  const api = Api.get().check((argv, context) => { _context = context })
 
-  let result = await api.parse('-x Hello', userContext)
+  let result = await api.parse('-x Hello', state)
   t.equal(result.code, 0)
   t.equal(result.argv.x, 'Hello')
-  t.equal(result.argv.$, userContext)
+  t.equal(_context.state, state)
 
   result = await api.parse('-x Hello')
   t.equal(result.code, 0)
   t.equal(result.argv.x, 'Hello')
-  t.equal(Object.keys(result.argv).indexOf('$'), -1)
+  t.equal(_context.state, undefined)
 })


### PR DESCRIPTION
### SUMMARY

Allow user to pass an optional additional data object (a "user context") to `.parse` or `.parseAndExit`, which is made available at `argv.$` to downstream methods.

Possibly fixes https://github.com/sywac/sywac/issues/58

```js
require('sywac')
    .parseAndExit(process.argv, { version: 3 })
    .then(argv => {
        console.log(argv.$.version)
    })
```

### DETAILS

I initially thought that we would make this additional user data available under the `context`, perhaps as something like `context.userContext`.  However, the context is actually not available in the general case -- yes, check/validation can see it, and yes, Command run handlers can see it, but if you use the general async form (like in the example above) there is no way to get access to the context.

My solution to that problem is to put it on argv instead, and use a symbol (`$`) that is unlikely to conflict with an actual flag name.

### POSSIBLE ALTERNATE SOLUTIONS

1. Pick a different name (perhaps `_context` or `$context` or `$data`).  The obvious problem is avoiding accidentally conflicting with a real program flag the user needs.

2. Solve the first problem I described and give access to sywac's context _through_ the argv.  If you did this, perhaps you'd access the new data like `argv.$context.userContext` (or `context.userContext` if in a check handler).

(From a lifecycle perspective, it might not be ideal to do this -- TODAY, we only give access to `context` in situations where calling methods on it will have an effect.  In a Command handler and/or a check callback, `context.cliMessage("blah")` will do something, whereas in my `.then()` at the top of this PR, it's too late.  I think we might want to keep that the same.)
