### PR TITLE
feat: customize error formatting and styling

### DIFF
--- a/api.js
+++ b/api.js
@@ -40,7 +40,6 @@ class Api {
     this._strictMode = 'strictMode' in opts ? opts.strictMode : false
     this._magicCommandAdded = false
     this._modulesSeen = opts.modulesSeen || []
-    this._errorFormatter = undefined
     this.configure(opts)
     if (!Api.ROOT_NAME) Api.ROOT_NAME = this.name
   }
@@ -60,6 +59,7 @@ class Api {
     // other
     this._name = opts.name || this._name
     this._parentName = opts.parentName || this._parentName // TODO this seems awfully hacky
+    this._unexpectedErrorFormatter = opts.unexpectedErrorFormatter || this._unexpectedErrorFormatter
     return this
   }
 
@@ -260,7 +260,7 @@ class Api {
   }
 
   unexpectedErrorFormatter (fn) {
-    this._errorFormatter = fn
+    this._unexpectedErrorFormatter = fn
     return this
   }
 
@@ -716,14 +716,14 @@ class Api {
       utils: this.utils,
       pathLib: this.pathLib,
       fsLib: this.fsLib,
-      errorFormatter: this._errorFormatter,
+      unexpectedErrorFormatter: this._unexpectedErrorFormatter,
       state,
 
       // Pass all help options (styling) down to the Context constructor. For the most
       // part, these options will be ignored, as the Context usually does not care about
       // styling - but it will pick up individual options if appropriate (such as
       // `styleUnexpectedError` if there is unexpected error).
-      ...this.helpOpts
+      helpOpts: this.helpOpts
     })
     return includeTypes ? this.applyTypes(context) : context
   }

--- a/context.js
+++ b/context.js
@@ -15,8 +15,8 @@ class Context {
     this._fsLib = opts.fsLib
     // config
     this.state = opts.state
-    this.errorFormatter = opts.errorFormatter
-    this.styleUnexpectedError = opts.styleUnexpectedError
+    this.unexpectedErrorFormatter = opts.unexpectedErrorFormatter
+    this.helpOpts = opts.helpOpts || {}
     this.types = {}
     // args to parse per type
     this.args = []
@@ -146,11 +146,11 @@ class Context {
 
   unexpectedError (err) {
     this.errors.push(err)
-    const message = typeof this.errorFormatter === 'function'
-      ? String(this.errorFormatter(err))
+    const message = typeof this.unexpectedErrorFormatter === 'function'
+      ? String(this.unexpectedErrorFormatter(err))
       : String((err && err.stack) || err)
-    this.output = typeof this.styleUnexpectedError === 'function'
-      ? this.styleUnexpectedError(message)
+    this.output = typeof this.helpOpts.styleUnexpectedError === 'function'
+      ? this.helpOpts.styleUnexpectedError(message)
       : message
     this.code++
   }

--- a/context.js
+++ b/context.js
@@ -15,6 +15,8 @@ class Context {
     this._fsLib = opts.fsLib
     // config
     this.state = opts.state
+    this.errorFormatter = opts.errorFormatter
+    this.styleUnexpectedError = opts.styleUnexpectedError
     this.types = {}
     // args to parse per type
     this.args = []
@@ -144,7 +146,12 @@ class Context {
 
   unexpectedError (err) {
     this.errors.push(err)
-    this.output = String((err && err.stack) || err)
+    const message = typeof this.errorFormatter === 'function'
+      ? String(this.errorFormatter(err))
+      : String((err && err.stack) || err)
+    this.output = typeof this.styleUnexpectedError === 'function'
+      ? this.styleUnexpectedError(message)
+      : message
     this.code++
   }
 

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -254,6 +254,22 @@ tap.test('api > style > unexpectedError styles error output', async t => {
   t.end()
 })
 
+tap.test('api > style > unexpectedError styles error output from subcommands', async t => {
+  // Custom styling and formatting, for good measure
+  const error = new Error('An Error')
+  const api = Api.get()
+    .unexpectedErrorFormatter(error => `(message: ${error.message})`)
+    .style({ unexpectedError: str => `(style: ${str})` })
+    .command('start', {
+      run: () => { throw error }
+    })
+
+  const result = await api.parse('start')
+  t.equal(result.output, '(style: (message: An Error))')
+
+  t.end()
+})
+
 tap.test('api > custom path and fs libs', async t => {
   class FakePath {
     // used by api

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -222,6 +222,38 @@ tap.test('api > attempt to get unmapped type returns null (don\'t do this)', t =
   t.end()
 })
 
+tap.test('api > unexpectedErrorFormatter customizes error output', async t => {
+  // Standard formatting
+  const error = new Error('An Error')
+  const api = Api.get().check(() => { throw error })
+  const result1 = await api.parse()
+  t.equal(result1.output, error.stack)
+
+  // Customized formatting
+  api.unexpectedErrorFormatter(error => `Oops, ${error.message} Happened`)
+  const result2 = await api.parse()
+  t.equal(result2.output, 'Oops, An Error Happened')
+
+  t.end()
+})
+
+tap.test('api > style > unexpectedError styles error output', async t => {
+  // Standard styling
+  const error = new Error('An Error')
+  const api = Api.get()
+    .unexpectedErrorFormatter(error => error.message)
+    .check(() => { throw error })
+  const result1 = await api.parse()
+  t.equal(result1.output, 'An Error')
+
+  // Customized styling
+  api.style({ unexpectedError: str => `[[${str}]]` })
+  const result2 = await api.parse()
+  t.equal(result2.output, '[[An Error]]')
+
+  t.end()
+})
+
 tap.test('api > custom path and fs libs', async t => {
   class FakePath {
     // used by api


### PR DESCRIPTION
### SUMMARY

* Customize _unexpected error formatting_ with `.unexpectedErrorFormatter()`.
* Customize _unexpected error styling_ with `unexpectedError` style hook.

### DETAILS

```js
require('sywac')
  .command('start', /* ... */)
  .command('stop', /* ... */)
  .unexpectedErrorFormatter(error => error.message)
  .style({ unexpectedError: str => chalk.red(str) })
  .parseAndExit()
```

This PR gives two ways to customize the formatting and/or the styling of the error output of an _unexpected error_ (an error thrown by a `run()` or `check()` handler, or added manually using `context.unexpectedError`).
