### PR TITLE
ESM discussion

### DIFF
--- a/api.js
+++ b/api.js
@@ -305,7 +305,7 @@ class Api {
   }
 
   // complex types
-  commandDirectory (dir, opts) {
+  async commandDirectory (dir, opts) {
     if (typeof dir === 'object') {
       opts = dir
       dir = ''
@@ -323,11 +323,12 @@ class Api {
     }
     let filepath
     let mod
-    this.fsLib.readdirSync(searchDir).forEach(fileInDir => {
+    await Promise.all(this.fsLib.readdirSync(searchDir).map(async fileInDir => {
       filepath = this.pathLib.join(searchDir, fileInDir)
       if (opts.extensions.indexOf(this.pathLib.extname(fileInDir)) !== -1 && this._modulesSeen.indexOf(filepath) === -1) {
         this._modulesSeen.push(filepath)
-        mod = require(filepath)
+        // mod = require(filepath)
+        mod = await import(filepath);
         if (mod.flags || mod.aliases) {
           this._internalCommand(mod)
         } else if (typeof mod === 'function') {
@@ -337,7 +338,7 @@ class Api {
           })
         }
       }
-    })
+    }));
     return this
   }
 


### PR DESCRIPTION
I realised when I was moving my projects from CJS to ESM that sywac is a blocker. I think 55f2ea8b9cab7724f2677bf0fac2024a30d8a057 may be all I need in order to move forward unless I hit other problems. ESM can consume CJS without to much fuss, but the other way around introduces a lot more friction, and since sywac consumes the command modules which are now in ESM it becomes a problem.

@nexdrew: What are your plans for migrating sywac to ESM? Are you thinking of:

* Maintaining both CJS and a new ESM project
* Just moving to ESM and potentially breaking any consumers apps that wish to upgrade but not also switch to ESM?
* Something else?

I'd be happy to help with the ESM effort, as I have a production CLI depending on sywac.

Thanks.